### PR TITLE
contrib.messaging.utils.send_message will always fail

### DIFF
--- a/lib/rapidsms/contrib/messaging/utils.py
+++ b/lib/rapidsms/contrib/messaging/utils.py
@@ -8,6 +8,6 @@ def send_message(connection, text):
     Send a message from the webui process to the router process,
     via the ajax app.
     """
-    return call_router("messaging", "send_message", 
-                       **{"connection_id": connection.id, "text": text })
-    
+    post = {"connection_id": unicode(connection.id), "text": text}
+    return call_router("messaging", "send_message", **post)
+


### PR DESCRIPTION
Currently, if you use the send_message utility function [1], it will fail due to connection.id being an integer (in ajax.utils). The whole send_message process itself is a little wonky, so I'm not sure if this is the best way to fix it, but converting it to a string before passing it along resolved my problem.

[1] https://github.com/rapidsms/rapidsms/blob/master/lib/rapidsms/contrib/messaging/utils.py#L6
