### PR TITLE
Fix a problem with line-breaks in incoming emails.

### DIFF
--- a/lib/rapidsms/backends/email.py
+++ b/lib/rapidsms/backends/email.py
@@ -148,7 +148,8 @@ class Backend(BackendBase):
             message.subject = subject
             return message
             
-        message = self.message(from_user, message_body.get_payload(), date)
+        body_nolb = message_body.get_payload().replace('\r','').replace('\n','')
+        message = self.message(from_user, body_nolb, date)
         message.subject = subject
         message.mime_type = message_body.get_content_type()
         return message


### PR DESCRIPTION
In our incoming mails, we had to fiddle with the body's payload for 
RapidSMS to actually handle the command - namely line-breaks had to 
replaced. It seems we don't have much influence on the line-breaks in 
the mail, but maybe it's a problem somewhere deep down the router 
process and not in the sent mail? 
