### PR TITLE
supports settings.DATABASES and fixes global name error 

### DIFF
--- a/lib/rapidsms/contrib/export/views.py
+++ b/lib/rapidsms/contrib/export/views.py
@@ -9,28 +9,46 @@ from django.conf import settings
 from django import http
 
 
+
 def database(req):
     """
     Return a SQL dump of the current database, by reading the settings
     from settings.py, and calling the relevant dump program. Currently,
     only mySQL and SQLite3 are supported.
     """
+    if settings.DATABASES:
+        if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
+            cmd = "mysqldump --host=%s --user=%s --password=%s %s" %\
+                (settings.DATABASES['default']['HOST'], settings.settings.DATABASES['default']['USER'],
+                 settings.DATABASES['default']['PASSWORD'], settings.DATABASES['default']['NAME'])
 
-    if settings.DATABASE_ENGINE == "mysql":
-        cmd = "mysqldump --host=%s --user=%s --password=%s %s" %\
+        elif settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3':
+            cmd = "sqlite3 %s .dump" %\
+                (settings.DATABASES['default']['NAME'])
+
+        else:
+            return http.HttpResponse(
+                "Sorry, %s databases are not supported yet." %\
+                    (settings.DATABASE_ENGINE),
+                content_type="text/plain",
+                status=500)
+
+    else:
+        if settings.DATABASE_ENGINE == "mysql":
+            cmd = "mysqldump --host=%s --user=%s --password=%s %s" %\
             (settings.DATABASE_HOST, settings.DATABASE_USER,
              settings.DATABASE_PASSWORD, settings.DATABASE_NAME)
 
-    elif settings.DATABASE_ENGINE == "sqlite3":
-        cmd = "sqlite3 %s .dump" %\
-            (settings.DATABASE_NAME)
+        elif settings.DATABASE_ENGINE == "sqlite3":
+            cmd = "sqlite3 %s .dump" %\
+                (settings.DATABASE_NAME)
 
-    else:
-        return HttpResponse(
-            "Sorry, %s databases are not supported yet." %\
-                (settings.DATABASE_ENGINE),
-            content_type="text/plain",
-            status=500)
+        else:
+            return HttpResponse(
+                "Sorry, %s databases are not supported yet." %\
+                    (settings.DATABASE_ENGINE),
+                content_type="text/plain",
+                status=500)
 
     # execute the dump command, and wait for it to terminate
     proc = Popen([cmd], shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)


### PR DESCRIPTION
The sorry message was failing due to a global name error. http.HttpResponse was added and fixed the bug.

settings.DATABASE_ENGINE was being used and did not recognize the new-er settings.DATABASES setup. Now both are supported. 
