### PR TITLE
this fixes the django auth context processor declaration as raised in issue #163

### DIFF
--- a/lib/rapidsms/skeleton/project/settings.py
+++ b/lib/rapidsms/skeleton/project/settings.py
@@ -134,7 +134,7 @@ LOG_BACKUPS = 256  # number of logs to keep
 # these weird dependencies should be handled by their respective apps,
 # but they're not, so here they are. most of them are for django admin.
 TEMPLATE_CONTEXT_PROCESSORS = [
-    "django.core.context_processors.auth",
+    "django.contrib.auth.context_processors.auth",
     "django.core.context_processors.debug",
     "django.core.context_processors.i18n",
     "django.core.context_processors.media",


### PR DESCRIPTION
The auth context processor has been moved from django.core.context_processors.auth to django.contrib.auth.context_processors.auth. The move started in Django 1.2, and django.core.context_processors.auth was completely removed in Django 1.4.

This pull request fixes the error that gets displayed if using RapidSMS with Django 1.4.
