### PR TITLE
add a default view for httptester that defaults to a configured backend

### DIFF
--- a/rapidsms/contrib/httptester/urls.py
+++ b/rapidsms/contrib/httptester/urls.py
@@ -7,6 +7,7 @@ from . import views
 
 
 urlpatterns = patterns('',
+    url(r"^$", views.default),
     url(r"^(?P<backend_name>[\w-]+)/$", views.generate_identity),
     url(r"^(?P<backend_name>[\w-]+)/(?P<identity>\d+)/$",
         views.message_tester),

--- a/rapidsms/contrib/httptester/views.py
+++ b/rapidsms/contrib/httptester/views.py
@@ -6,11 +6,17 @@ from random import randint
 
 from django.template import RequestContext
 from django.shortcuts import render_to_response
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from . import forms
 from . import storage
 
+def default(request):
+    default_backend = settings.HTTPTESTER_BACKEND \
+        if hasattr(settings, 'HTTPTESTER_BACKEND') \
+        else settings.INSTALLED_BACKENDS.keys()[0]
+    return generate_identity(request, default_backend)
 
 def generate_identity(request, backend_name):
     identity = randint(111111, 999999)


### PR DESCRIPTION
- checks for settings.HTTPTESTER_BACKEND to choose which backend to use.
- if no configured backend is found it will arbitrarily choose one which
  is probably not ideal, though better than failing hard (?)
- this allows httptester to be compatible with RAPIDSMS_TABS
