### PR TITLE
patched up `conf.py` to compile docs within rapidsms folder without having to install RapidSMS first

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 


### PR DESCRIPTION
This is especially useful for folks that directly add their rapidsms(contrib) apps to their projects without installing these apps (either in site-packages or other). Docs are a critical part especially during offline dev work; hope this makes sense.
