### PR TITLE
"Installation Successful!" page links to old wiki

### DIFF
--- a/rapidsms/templates/dashboard.html
+++ b/rapidsms/templates/dashboard.html
@@ -37,7 +37,7 @@
 
 	<div>
 		<p>
-			See <a href="http://docs.rapidsms.org/Installation">the RapidSMS wiki</a>
+			See <a href="http://rapidsms.readthedocs.org/en/latest/intro/install/index.html">the RapidSMS documentation</a>
 			to learn how to install community apps or create your own.
 		</p>
 


### PR DESCRIPTION
The installation successful page links to http://docs.rapidsms.org/Installation. This should point to rapidsms.readthedocs.org.
