### PR TITLE
Naive datetime warnings

### DIFF
--- a/rapidsms/backends/kannel/tests.py
+++ b/rapidsms/backends/kannel/tests.py
@@ -3,6 +3,7 @@ import datetime
 from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.conf.urls import patterns, url
+from django.utils.timezone import now
 
 from rapidsms.backends.kannel import views
 from rapidsms.backends.kannel import KannelBackend
@@ -153,7 +154,7 @@ class KannelDeliveryReportTest(CreateDataMixin, TestCase):
                  'status_text': 'Success',
                  'smsc': 'usb0-modem',
                  'sms_id': self.random_string(36),
-                 'date_sent': datetime.datetime.now()}
+                 'date_sent': now()}
         url = reverse('kannel-delivery-report')
         response = self.client.get(url, query)
         self.assertEqual(200, response.status_code)
@@ -170,7 +171,7 @@ class KannelDeliveryReportTest(CreateDataMixin, TestCase):
                  'status_text': 'Success',
                  'smsc': 'usb0-modem',
                  'sms_id': self.random_string(36),
-                 'date_sent': datetime.datetime.now()}
+                 'date_sent': now()}
         url = reverse('kannel-delivery-report')
         response = self.client.get(url, query)
         self.assertEqual(400, response.status_code)

--- a/rapidsms/contrib/messagelog/tests/models.py
+++ b/rapidsms/contrib/messagelog/tests/models.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # vim: aui ts=4 sts=4 et sw=4
 
-import datetime
 from django.core.exceptions import ValidationError
+from django.utils.timezone import now
 from rapidsms.tests.harness import RapidTest
 from ..models import Message
 
@@ -20,7 +20,7 @@ class MessageLogModelTest(RapidTest):
             'contact': self.contact,
             'connection': self.connection,
             'direction': Message.INCOMING,
-            'date': datetime.datetime.now(),
+            'date': now(),
             'text': 'hello',
         }
 

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -3,11 +3,12 @@
 
 import logging
 import warnings
-import datetime
 import copy
 from collections import defaultdict
 
 from django.db.models.query import QuerySet
+from django.utils.timezone import now
+
 from rapidsms.messages.incoming import IncomingMessage
 from rapidsms.messages.outgoing import OutgoingMessage
 from rapidsms.backends.base import BackendBase
@@ -278,7 +279,7 @@ class BlockingRouter(object):
         :returns: :class:`IncomingMessage <rapidsms.messages.incoming.IncomingMessage>` object.
         """
         return class_(text=text, connections=connections,
-                      received_at=datetime.datetime.now(),
+                      received_at=now(),
                       **kwargs)
 
     def new_outgoing_message(self, text, connections, class_=OutgoingMessage,

--- a/rapidsms/router/db/models.py
+++ b/rapidsms/router/db/models.py
@@ -1,6 +1,6 @@
-import datetime
-
 from django.db import models
+from django.utils.timezone import now
+
 from rapidsms.models import Connection
 
 
@@ -41,10 +41,10 @@ class Message(models.Model):
                 self.status = 'P'
             elif self.transmissions.exclude(status__in=['D']).exists():
                 self.status = 'S'
-                self.sent = datetime.datetime.now()
+                self.sent = now()
             else:
                 self.status = 'D'
-                self.delivered = datetime.datetime.now()
+                self.delivered = now()
         else:
             if self.transmissions.filter(status='E').exists():
                 self.status = 'E'
@@ -52,7 +52,7 @@ class Message(models.Model):
                 self.status = 'Q'
             else:
                 self.status = 'R'
-        self.updated = datetime.datetime.now()
+        self.updated = now()
         self.save()
         return self.status
 


### PR DESCRIPTION
Running with Django 1.4 and USE_TZ=True, I get warnings like:

```
local/lib/python2.7/site-packages/django/db/models/fields/__init__.py:827:
RuntimeWarning: DateTimeField received a naive datetime (2013-03-20 15:02:45.949419)
while time zone support is active.
```

Let's review rapidsms datetime usage with https://docs.djangoproject.com/en/1.4/topics/i18n/timezones/#time-zones-migration-guide in mind and see if we can make this work as expected.
