### PR TITLE
Don't use deprecated LoggerMixin

### DIFF
--- a/docs/releases/0.13.0.rst
+++ b/docs/releases/0.13.0.rst
@@ -34,6 +34,12 @@ What's New
     import logging
     logger = logging.getLogger(__name__)
 
+  That includes code that might use LoggerMixin indirectly by extending
+  ``AppBase``, ``BackendBase``, or ``BaseHandler``.  Search for code like
+  ``self.error(...)`` or ``self.debug(...)`` and change to
+  ``logger.error(...)`` or ``logger.debug(...)`` after creating a logger
+  object as above.
+
 
 .. _backwards-incompatible-changes-0.13.0:
 

--- a/rapidsms/tests/harness/base.py
+++ b/rapidsms/tests/harness/base.py
@@ -2,7 +2,6 @@ import string
 import random
 
 from rapidsms.models import Backend, Contact, Connection
-from rapidsms.log.mixin import LoggerMixin
 from rapidsms.messages.outgoing import OutgoingMessage
 from rapidsms.messages.incoming import IncomingMessage
 
@@ -13,7 +12,7 @@ __all__ = ('CreateDataMixin',)
 UNICODE_CHARS = [unichr(x) for x in xrange(1, 0xD7FF)]
 
 
-class CreateDataMixin(object, LoggerMixin):
+class CreateDataMixin(object):
     """Base test mixin class that provides helper functions to create data"""
 
     def random_string(self, length=255, extra_chars=''):


### PR DESCRIPTION
RapidSMS's own code shouldn't use LoggerMixin anymore, as it's deprecated starting in v0.13.0.
