### PR TITLE
Update Vumi docs to point to develop

### DIFF
--- a/docs/internals/roadmap/interoperability.rst
+++ b/docs/internals/roadmap/interoperability.rst
@@ -24,8 +24,7 @@ A super-scalable conversation engine for the delivery of SMS.
 * `Vumi website <http://www.vumi.org/>`_, `Vumi Developers Portal <http://vumi.readthedocs.org/en/latest/index.html>`_
 * Architecture: Python
 * Features: Message sending framework. Can write Vumi-level applications for deeper integration. Can be used as a hosted service?
-* RapidSMS Interoperability
-    * Backend: https://github.com/rapidsms/rapidsms/tree/feature/vumi-backend
+* RapidSMS Interoperability: support has been integrated into RapidSMS 0.13
 
 DHIS
 ----

--- a/docs/topics/backends/vumi.rst
+++ b/docs/topics/backends/vumi.rst
@@ -56,14 +56,14 @@ Installing and setting up Vumi for the first time
 
     As of this writing, the RapidSMS/Vumi integration is planned for merge into
     an official Vumi release, but currently resides in the
-    ``feature/issue-302-rapidsms-relay`` Vumi branch. When complete, we
+    ``develop`` Vumi branch. When complete, we
     will update this documentation accordingly.
 
 Clone the Vumi `GitHub repository <https://github.com/praekelt/vumi>`_::
 
     git clone git@github.com:praekelt/vumi.git
     cd vumi
-    git checkout feature/issue-302-rapidsms-relay
+    git checkout develop
 
 Install Vumi's Python dependencies::
 


### PR DESCRIPTION
The Vumi pull request has been [merged](https://github.com/praekelt/vumi/pull/303). We should update the docs to no longer checkout the feature branch.
