### PR TITLE
Show inheritance tree of testing harness classes

### DIFF
--- a/docs/topics/router/blocking.rst
+++ b/docs/topics/router/blocking.rst
@@ -68,3 +68,7 @@ functionality. A subset of its methods are outlined below:
     :members: incoming_phases,outgoing_phases,add_app,get_app,add_backend,
               receive_incoming,send_outgoing,new_incoming_message,
               new_outgoing_message
+
+.. class:: rapidsms.router.blocking.router.BlockingRouter
+
+    is the full name for :py:class:`rapidsms.router.blocking.BlockingRouter`.

--- a/docs/topics/testing.rst
+++ b/docs/topics/testing.rst
@@ -83,14 +83,14 @@ General Testing
 ***************
 
 RapidSMS provides a suite of test harness tools. Below you'll find a collection
-of ``TestCase`` extensions to make testing your RapidSMS applications easier.
+of :py:class:`django.test.TestCase` extensions to make testing your RapidSMS applications easier.
 
 .. _rapidtest:
 
 RapidTest
 ~~~~~~~~~
 
-The ``RapidTest`` class provides a simple test environment to analyze sent and
+The :py:class:`~rapidsms.tests.harness.RapidTest` class provides a simple test environment to analyze sent and
 received messages. You can inspect messages processed by the router and, if
 needed, see if messages were delivered to a special backend, ``mockbackend``.
 Let's take a look at a simple example::
@@ -114,26 +114,13 @@ text. That's it! With just a few lines we were able to send a message through
 the entire routing stack and verify the functionality of our application.
 
 .. autoclass:: rapidsms.tests.harness.RapidTest
-    :members: inbound, outbound, sent_messages, clear_sent_messages, receive, send, lookup_connections
-
-    .. attribute:: apps
-
-        A list of app classes to load, rather than ``INSTALLED_APPS``, when the
-        router is initialized.
-
-    .. attribute:: disable_phases = False
-
-        If ``disable_phases`` is True, messages will not be processed through
-        the router phases.
-        This is useful if you're not interested in testing application logic.
-        For example, backends may use this flag to ensure messages are sent to
-        the router, but don't want the message to be processed.
+    :members:
 
 
 Database Interaction
 ^^^^^^^^^^^^^^^^^^^^
 
-``RapidTest`` provides flexible means to check application state, including
+:py:class:`~rapidsms.tests.harness.RapidTest` provides flexible means to check application state, including
 the database. Here's an example of a test that examines the database after
 receiving a message::
 
@@ -193,7 +180,7 @@ your test suite. For example::
 
 This example tests the logic of ``QuizMeApp.is_quiz``, which is used to
 determine whether or not the text message is related to the quiz application.
-The app is constructed with ``TestRouter`` and tests ``is_quiz`` with various
+The app is constructed with :py:class:`~rapidsms.router.test.TestRouter` and tests ``is_quiz`` with various
 types of input.
 
 This method is useful for testing specific, low-level components of your
@@ -204,7 +191,9 @@ Scripted Tests
 **************
 
 You can write high-level integration tests for your applications by using the
-``TestScript`` framework. ``TestScript`` allows you to write message *scripts*
+:py:class:`~rapidsms.tests.harness.TestScript` framework.
+:py:class:`~rapidsms.tests.harness.TestScript`
+allows you to write message *scripts*
 (akin to a movie script), similar to our example in the :ref:`what-to-test`
 section above::
 
@@ -233,9 +222,12 @@ Example
 ~~~~~~~
 
 To use this functionality in your test suite, you simply need to extend from
-``TestScript`` to get access to ``runScript``::
+:py:class:`~rapidsms.tests.harness.TestScript` or
+:py:class:`~rapidsms.tests.harness.TestScriptMixin`
+to get access to
+:py:meth:`~rapidsms.tests.harness.TestScriptMixin.runScript`::
 
-    from rapidsms.tests.harness.scripted import TestScript
+    from rapidsms.tests.harness import TestScript
     from quizme.app import QuizMeApp
     from quizme.models import Question
 
@@ -265,6 +257,16 @@ tests across multiple RapidSMS applications. However, you're limited to the
 test script. If you need more fined grained access, like checking the state of
 the database in the middle of a script, you should use :ref:`general-testing`.
 
+.. autoclass:: rapidsms.tests.harness.TestScript
+    :members:
+
+.. autoclass:: rapidsms.tests.harness.TestScriptMixin
+    :members:
+
+.. class:: rapidsms.tests.harness.scripted.TestScriptMixin
+
+    Full name of :py:class:`rapidsms.tests.harness.TestScriptMixin`.
+
 
 Test Helpers
 ************
@@ -292,44 +294,12 @@ make it easier to create common RapidSMS models and objects. For example::
             text = self.random_string()
             # ...
 
-.. class:: CreateDataMixin
+.. autoclass:: rapidsms.tests.harness.CreateDataMixin
+    :members:
 
-    .. method:: random_string(length=255, extra_chars='')
+.. class:: rapidsms.tests.harness.base.CreateDataMixin
 
-        Generate a random string of characters.
-
-        :param length: Length of generated string.
-        :param extra_chars: Additional characters to include in generated string.
-
-    .. method:: random_unicode_string(max_length=255)
-
-        Generate a random string of unicode characters.
-
-        :param length: Length of generated string.
-
-    .. method:: create_backend(data={})
-
-        Create and return RapidSMS backend object. A random ``name`` will be created if not specified in ``data`` attribute.
-
-        :param data: Optional dictionary of field name/value pairs to pass to the object's ``create`` method.
-
-    .. method:: create_contact(data={})
-
-        Create and return RapidSMS contact object. A random ``name`` will be created if not specified in ``data`` attribute.
-
-        :param data: Optional dictionary of field name/value pairs to pass to the object's ``create`` method.
-
-    .. method:: create_connection(data={})
-
-        Create and return RapidSMS connection object. A random ``identity`` and ``backend`` will be created if not specified in ``data`` attribute.
-
-        :param data: Optional dictionary of field name/value pairs to pass to the object's ``create`` method.
-
-    .. method:: create_outgoing_message(data={})
-
-        Create and return RapidSMS OutgoingMessage object. A random ``template`` will be created if not specified in ``data`` attribute.
-
-        :param data: Optional dictionary of field name/value pairs to pass to ``OutgoingMessage.__init__``.
+    Full name for :py:class:`rapidsms.tests.harness.CreateDataMixin`.
 
 CustomRouterMixin
 ~~~~~~~~~~~~~~~~~
@@ -350,12 +320,69 @@ The ``CustomRouterMixin`` class allows you to override the :setting:`RAPIDSMS_RO
             # this test will use specified router and backends
             pass
 
-.. class:: CustomRouterMixin
+.. autoclass:: rapidsms.tests.harness.CustomRouterMixin
+    :members:
 
-    .. attribute:: router_class
 
-        String to override :setting:`RAPIDSMS_ROUTER` during testing. Defaults to ``'rapidsms.router.blocking.BlockingRouter'``.
+.. class:: rapidsms.tests.harness.router.CustomRouterMixin
 
-    .. attribute:: backends
+    Full name for :py:class:`rapidsms.tests.harness.CustomRouterMixin`.
 
-        Dictionary to override :setting:`INSTALLED_BACKENDS` during testing. Defaults to ``{}``.
+
+TestRouterMixin
+~~~~~~~~~~~~~~~
+
+``TestRouterMixin`` extends CustomRouterMixin and arranges for tests
+to use the :py:class:`rapidsms.router.test.TestRouter`.
+
+.. autoclass:: rapidsms.tests.harness.TestRouterMixin
+    :members:
+
+    .. attribute:: apps
+
+        A list of app classes to load, rather than ``INSTALLED_APPS``, when the
+        router is initialized.
+
+
+.. class:: rapidsms.tests.harness.router.TestRouterMixin
+
+    Full name for :py:class:`rapidsms.tests.harness.TestRouterMixin`.
+
+
+TestRouter
+~~~~~~~~~~
+
+The ``TestRouter`` can be used in tests. It saves all messages for later
+inspection by the test.
+
+.. autoclass:: rapidsms.router.test.TestRouter
+    :members:
+
+
+DatabaseBackendMixin
+~~~~~~~~~~~~~~~~~~~~
+
+The ``DatabaseBackendMixin`` helps tests to use the DatabaseBackend.
+
+.. autoclass:: rapidsms.tests.harness.DatabaseBackendMixin
+    :members:
+
+
+LoginMixin
+~~~~~~~~~~
+
+.. autoclass:: rapidsms.tests.harness.LoginMixin
+    :members:
+
+.. class:: rapidsms.tests.harness.base.LoginMixin
+
+    Full name for :py:class:`rapidsms.tests.harness.LoginMixin`.
+
+Django TestCase
+~~~~~~~~~~~~~~~
+
+Some of these classes inherit from:
+
+.. class:: django.test.testcases.TestCase
+
+which is the full name for :py:class:`django.test.TestCase`.

--- a/rapidsms/router/test/router.py
+++ b/rapidsms/router/test/router.py
@@ -4,11 +4,19 @@ from rapidsms.router.blocking import BlockingRouter
 
 
 class TestRouter(BlockingRouter):
-    """Router that saves inbound/outbound messages for future inspection."""
+    """Router that saves inbound/outbound messages for future inspection.
+
+    Inherits from :router:`BlockingRouter`.
+    """
 
     def __init__(self, *args, **kwargs):
+
+        #: List of all the inbound messages
         self.inbound = []
+
+        #: List of all the outbound messages
         self.outbound = []
+
         self.disable_phases = kwargs.pop('disable_phases', False)
         super(TestRouter, self).__init__(*args, **kwargs)
 

--- a/rapidsms/tests/harness/__init__.py
+++ b/rapidsms/tests/harness/__init__.py
@@ -14,14 +14,28 @@ from rapidsms.tests.harness.app import MockApp, EchoApp, ExceptionApp
 
 
 class RapidTest(TestRouterMixin, LoginMixin, TestCase):
+    """
+    Inherits from :py:class:`~rapidsms.tests.harness.TestRouterMixin`,
+    :py:class:`~rapidsms.tests.harness.LoginMixin`,
+    :py:class:`~django.test.TestCase`.
+    """
     pass
 
 
-class RapidTransactionTest(TestRouterMixin,  LoginMixin, TransactionTestCase):
+class RapidTransactionTest(TestRouterMixin, LoginMixin, TransactionTestCase):
+    """
+    Inherits from :py:class:`~rapidsms.tests.harness.TestRouterMixin`,
+    :py:class:`~rapidsms.tests.harness.LoginMixin`,
+    :py:class:`~django.test.TransactionTestCase`.
+    """
     pass
 
 
 class TestScript(TestScriptMixin, TestCase):
+    """
+    Inherits from :py:class:`~rapidsms.tests.harness.TestScriptMixin`,
+    :py:class:`~django.test.TransactionTestCase`.
+    """
     pass
 
 

--- a/rapidsms/tests/harness/base.py
+++ b/rapidsms/tests/harness/base.py
@@ -14,15 +14,26 @@ UNICODE_CHARS = [unichr(x) for x in xrange(1, 0xD7FF)]
 
 
 class CreateDataMixin(object):
-    """Base test mixin class that provides helper functions to create data"""
+    """Base test mixin class that provides helper functions to create data.
+
+    No superclasses.
+    """
 
     def random_string(self, length=255, extra_chars=''):
-        """Generate a random string of characters."""
+        """ Generate a random string of characters.
+
+        :param length: Length of generated string.
+        :param extra_chars: Additional characters to include in generated
+            string.
+        """
         chars = string.letters + extra_chars
         return ''.join([random.choice(chars) for i in range(length)])
 
     def random_unicode_string(self, max_length=255):
-        """Generate a random string of unicode characters."""
+        """Generate a random string of unicode characters.
+
+        :param length: Length of generated string.
+        """
         output = u''
         for x in xrange(random.randint(1, max_length / 2)):
             c = UNICODE_CHARS[random.randint(0, len(UNICODE_CHARS) - 1)]
@@ -30,7 +41,12 @@ class CreateDataMixin(object):
         return output
 
     def create_backend(self, data={}):
-        """Create and return RapidSMS backend object."""
+        """Create and return RapidSMS backend object. A random ``name``
+        will be created if not specified in ``data`` attribute.
+
+        :param data: Optional dictionary of field name/value pairs to pass
+            to the object's ``create`` method.
+        """
         defaults = {
             'name': self.random_string(12),
         }
@@ -38,7 +54,11 @@ class CreateDataMixin(object):
         return Backend.objects.create(**defaults)
 
     def create_contact(self, data={}):
-        """Create and return RapidSMS contact object."""
+        """ Create and return RapidSMS contact object. A random ``name``
+        will be created if not specified in ``data`` attribute.
+
+        :param data: Optional dictionary of field name/value pairs to
+            pass to the object's ``create`` method."""
         defaults = {
             'name': self.random_string(12),
         }
@@ -46,7 +66,12 @@ class CreateDataMixin(object):
         return Contact.objects.create(**defaults)
 
     def create_connection(self, data={}):
-        """Create and return RapidSMS connection object."""
+        """ Create and return RapidSMS connection object. A random
+        ``identity`` and ``backend`` will be created if not specified in
+        ``data`` attribute.
+
+        :param data: Optional dictionary of field name/value pairs
+            to pass to the object's ``create`` method."""
         defaults = {
             'identity': self.random_string(10),
         }
@@ -56,7 +81,11 @@ class CreateDataMixin(object):
         return Connection.objects.create(**defaults)
 
     def create_outgoing_message(self, data={}, backend=None):
-        """Create and return RapidSMS OutgoingMessage object."""
+        """Create and return RapidSMS OutgoingMessage object. A random
+        ``template`` will be created if not specified in ``data`` attribute.
+
+        :param data: Optional dictionary of field name/value pairs to pass
+            to ``OutgoingMessage.__init__``."""
         defaults = {
             'text': self.random_string(10),
         }
@@ -80,8 +109,14 @@ class CreateDataMixin(object):
 
 
 class LoginMixin(object):
-    # Helpers for creating users and logging in
+    """Helpers for creating users and logging in"""
     def login(self):
+        """If not already set, creates self.username and self.password,
+        otherwise uses the existing values.
+        If there's not already a user with that username, creates one.
+        Sets self.user to that user.
+        Logs the user in.
+        """
         if not hasattr(self, 'username'):
             self.username = 'fred'
         if not hasattr(self, 'password'):

--- a/rapidsms/tests/harness/router.py
+++ b/rapidsms/tests/harness/router.py
@@ -12,9 +12,17 @@ __all__ = ('CustomRouter', 'MockBackendRouter')
 
 
 class CustomRouterMixin(CreateDataMixin):
-    """Inheritable TestCase-like object that allows Router customization."""
+    """Inheritable TestCase-like object that allows Router customization.
 
+    Inherits from :py:class:`~rapidsms.tests.harness.CreateDataMixin`.
+    """
+
+    #: String to override :setting:`RAPIDSMS_ROUTER` during testing. Defaults
+    #: to ``'rapidsms.router.blocking.BlockingRouter'``.
     router_class = 'rapidsms.router.blocking.BlockingRouter'
+
+    #: Dictionary to override :setting:`INSTALLED_BACKENDS` during testing.
+    #: Defaults to ``{}``.
     backends = {}
 
     def _pre_rapidsms_setup(self):
@@ -58,6 +66,12 @@ class CustomRouterMixin(CreateDataMixin):
 
 
 class DatabaseBackendMixin(CustomRouterMixin):
+    """Arrange for test to use the DatabaseBackend, and add
+    a ``.sent_messages`` attribute that will have the list
+    of all messages sent.
+
+    Inherits from :py:class:`~rapidsms.tests.harness.CustomRouterMixin`.
+    """
 
     backends = {'mockbackend': {'ENGINE': DatabaseBackend}}
 
@@ -66,7 +80,7 @@ class DatabaseBackendMixin(CustomRouterMixin):
         super(DatabaseBackendMixin, self).setUp()
 
     def lookup_connections(self, identities, backend='mockbackend'):
-        """loopup_connections wrapper to use mockbackend by default"""
+        """lookup_connections wrapper to use mockbackend by default"""
         return super(DatabaseBackendMixin, self).lookup_connections(backend,
                                                                     identities)
 
@@ -78,7 +92,10 @@ class DatabaseBackendMixin(CustomRouterMixin):
 
 
 class TestRouterMixin(CustomRouterMixin):
-    """Test extension that uses TestRouter"""
+    """Test extension that uses TestRouter
+
+    Inherits from :py:class:`~rapidsms.tests.harness.CustomRouterMixin`.
+    """
 
     #: If `disable_phases` is True, messages will not be processed through the
     #: router phases.

--- a/rapidsms/tests/harness/scripted.py
+++ b/rapidsms/tests/harness/scripted.py
@@ -11,7 +11,7 @@ class TestScriptMixin(TestRouterMixin):
     """
     The scripted.TestScript class subclasses unittest.TestCase
     and allows you to define unit tests for your RapidSMS apps
-    in the form of a 'conversational' script:
+    in the form of a 'conversational' script::
 
         from myapp.app import App as MyApp
         from rapidsms.tests.scripted import TestScript
@@ -28,9 +28,12 @@ class TestScriptMixin(TestRouterMixin):
                8005550000 < someuser said "what's up??"
             \"""
 
+
     This TestMyApp class would then work exactly as any other
     unittest.TestCase subclass (so you could, for example, call
     unittest.main()).
+
+    Inherits from :py:class:`~rapidsms.tests.harness.router.TestRouterMixin`.
     """
 
     def assertInteraction(self, script):
@@ -106,5 +109,10 @@ class TestScriptMixin(TestRouterMixin):
             last_msg = txt
 
     def runScript(self, script):
+        """Run a test script.
+
+        :param string script: A multi-line test script. See
+            :py:class:`~rapidsms.tests.harness.scripted.TestScriptMixin`.
+        """
         self.clear_sent_messages()  # make sure the outbox is empty
         self.runParsedScript(self.parseScript(script))


### PR DESCRIPTION
The <a href="http://rapidsms.readthedocs.org/en/latest/topics/testing.html">testing docs</a> don't cover the complex inheritance tree of the testing mixins - for example, that `CustomRouterMixin` is not separate from `CreateDataMixin` but actually inherits from it. This is confusing and should probably be clarified.

@dpoirier pointed out that we can make more use of autodoc to show inherited classes.
