### PR TITLE
Add contrib.messaging output to base.html

### DIFF
--- a/docs/releases/0.15.0.rst
+++ b/docs/releases/0.15.0.rst
@@ -9,6 +9,8 @@ aware of when upgrading from RapidSMS 0.14.0.
 What's New
 ==========
 
+ * :ref:`messages_to_users` are displayed at the top of the page if you're
+   using the RapidSMS base template.
  * ...
 
  .. _backwards-incompatible-changes-0.15.0:

--- a/docs/topics/frontend.rst
+++ b/docs/topics/frontend.rst
@@ -218,6 +218,15 @@ another contrib app,
       </div>
     {% endblock %}
 
+.. _messages_to_users:
+
+Messages to Users
+-----------------
+
+.. versionadded:: 0.15.0
+
+If you use the `Django messages framework`_ to send messages to your users, the base
+template will display them nicely above the page content.
 
 
 .. _Twitter Bootstrap: http://twitter.github.com/bootstrap/
@@ -225,3 +234,4 @@ another contrib app,
 .. _navigation bar: http://twitter.github.com/bootstrap/components.html#navbar
 .. _django_tables2: http://django-tables2.readthedocs.org/en/latest/
 .. _forms: http://twitter.github.com/bootstrap/base-css.html#forms
+.. _Django messages framework: https://docs.djangoproject.com/en/dev/ref/contrib/messages/

--- a/rapidsms/contrib/httptester/views.py
+++ b/rapidsms/contrib/httptester/views.py
@@ -3,6 +3,7 @@
 
 
 from random import randint
+from django.contrib import messages
 
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
@@ -52,18 +53,22 @@ def message_tester(request, identity):
             identity = cd["identity"]
             if 'clear-all-btn' in request.POST:
                 storage.clear_all_messages()
+                messages.add_message(request, messages.INFO, "Cleared all messages")
             elif 'clear-btn' in request.POST:
                 storage.clear_messages(identity)
+                messages.add_message(request, messages.INFO, "Cleared %s messages" % identity)
             else:
                 if "bulk" in request.FILES:
                     for line in request.FILES["bulk"]:
                         line = line.rstrip("\n")
                         storage.store_and_queue(identity, line)
+                    messages.add_message(request, messages.INFO, "Sent bulk messages")
                 # no bulk file was submitted, so use the "single message"
                 # field. this may be empty, which is fine, since contactcs
                 # can (and will) submit empty sms, too.
                 else:
                     storage.store_and_queue(identity, cd["text"])
+                    messages.add_message(request, messages.INFO, "Sent message")
             url = reverse(message_tester, args=[identity])
             return HttpResponseRedirect(url)
 

--- a/rapidsms/contrib/registration/views.py
+++ b/rapidsms/contrib/registration/views.py
@@ -2,6 +2,7 @@
 # vim: ai ts=4 sts=4 et sw=4
 
 import csv
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.db import transaction
@@ -54,6 +55,7 @@ def contact(request, pk=None):
         if pk:
             if request.POST["submit"] == "Delete Contact":
                 contact.delete()
+                messages.add_message(request, messages.INFO, "Deleted contact")
                 return HttpResponseRedirect(reverse(registration))
             contact_form = ContactForm(request.POST, instance=contact)
         else:
@@ -65,6 +67,7 @@ def contact(request, pk=None):
             if connection_formset.is_valid():
                 contact.save()
                 connection_formset.save()
+                messages.add_message(request, messages.INFO, "Added contact")
                 return HttpResponseRedirect(reverse(registration))
     return render(request, 'registration/contact_form.html', {
         "contact": contact,
@@ -111,6 +114,8 @@ def contact_bulk_add(request):
                 "bulk_form": bulk_form,
                 "csv_errors": "No contacts found in file",
             })
+        messages.add_message(request, messages.INFO, "Added %d contacts" %
+                                                     count)
         return HttpResponseRedirect(reverse(registration))
     return render(request, 'registration/bulk_form.html', {
         "bulk_form": bulk_form,

--- a/rapidsms/templates/base.html
+++ b/rapidsms/templates/base.html
@@ -93,6 +93,17 @@
                     </div>{% endif %}
                 {% endblock %}
 
+                {% block messages %}
+                  <div id="messages">
+                    {% for message in messages %}
+                      <div class="alert{% if message.tags %} alert-{{ message.tags }}"{% endif %}>
+                         <a class="close" data-dismiss="alert" href="#">&times;</a>
+                        {{ message }}
+                      </div>
+                     {% endfor %}
+                  </div>
+                {% endblock messages %}
+
                 <div class="row-fluid content">
                     {% block content %}{% endblock %}
                 </div>


### PR DESCRIPTION
We should use the Django messages framework internally for user messages (in contrib views) and it should be included by default in base.html for external apps. We should update the standard format to use bootstrap styles:

https://docs.djangoproject.com/en/1.5/ref/contrib/messages/#displaying-messages
