### PR TITLE
Validate router, apps, and handlers during startup

### DIFF
--- a/docs/releases/0.15.0.rst
+++ b/docs/releases/0.15.0.rst
@@ -13,6 +13,11 @@ What's New
    are loaded. :setting:`INSTALLED_HANDLERS`, :setting:`EXCLUDED_HANDLERS`,
    and :setting:`RAPIDSMS_HANDLERS_EXCLUDE_APPS` are deprecated. For more
    information see :ref:`handlers-discovery`.
+ * If there are any errors that would prevent the router, apps, or handlers
+   from being initialized, they will result in an ImproperlyConfigured
+   exception occurring during startup, causing startup to fail. Previously,
+   this kind of error might not be discovered until the first request was
+   processed, and perhaps not even then unless you looked at the logs.
  * ...
 
  .. _backwards-incompatible-changes-0.15.0:

--- a/rapidsms/contrib/handlers/app.py
+++ b/rapidsms/contrib/handlers/app.py
@@ -16,6 +16,7 @@ class App(AppBase):
         Spiders all apps, and registers all available handlers.
         """
         super(App, self).__init__(*args, **kwargs)
+        # Let get_handlers errors propagate, they're verbose enough
         self.handlers = get_handlers()
         if len(self.handlers):
             class_names = [cls.__name__ for cls in self.handlers]

--- a/rapidsms/contrib/handlers/utils.py
+++ b/rapidsms/contrib/handlers/utils.py
@@ -2,6 +2,7 @@
 # vim: ai ts=4 sts=4 et sw=4
 
 from warnings import warn
+from django.core.exceptions import ImproperlyConfigured
 
 from rapidsms.conf import settings
 from rapidsms.utils.modules import (find_python_files, get_class,
@@ -21,7 +22,14 @@ def get_handlers():
     """
 
     if hasattr(settings, 'RAPIDSMS_HANDLERS'):
-        return [import_class(name) for name in settings.RAPIDSMS_HANDLERS]
+        retval = []
+        for name in settings.RAPIDSMS_HANDLERS:
+            try:
+                cls = import_class(name)
+            except Exception as e:
+                raise ImproperlyConfigured("Cannot load handler %s: %s" % (name, e))
+            retval.append(cls)
+        return retval
 
     warn("Please set RAPIDSMS_HANDLERS to the handlers that should "
          "be installed. The old behavior of installing all defined "

--- a/rapidsms/models.py
+++ b/rapidsms/models.py
@@ -3,6 +3,7 @@
 
 
 from django.db import models
+from rapidsms.router import get_router
 from .utils.modules import try_import, get_classes
 from .conf import settings
 
@@ -169,3 +170,7 @@ class Connection(ConnectionBase):
     """
 
     __metaclass__ = ExtensibleModelBase
+
+
+# Make sure we can create a router
+get_router()

--- a/rapidsms/router/api.py
+++ b/rapidsms/router/api.py
@@ -3,7 +3,6 @@ import collections
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from rapidsms.models import Backend
 from rapidsms.utils.modules import import_class
 
 
@@ -14,8 +13,8 @@ def get_router():
     if isinstance(router, basestring):
         try:
             router = import_class(router)()
-        except ImportError as e:
-            raise ImproperlyConfigured(e)
+        except Exception as e:
+            raise ImproperlyConfigured("Cannot create router of class %s: %s" % (router, e))
     return router
 
 
@@ -80,6 +79,8 @@ def lookup_connections(backend, identities):
     :returns: List of :py:class:`~rapidsms.models.Connection` objects
     """
     if isinstance(backend, basestring):
+        # Avoid circular import
+        from rapidsms.models import Backend
         backend, _ = Backend.objects.get_or_create(name=backend)
     connections = []
     for identity in identities:

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -5,6 +5,7 @@ import logging
 import warnings
 import copy
 from collections import defaultdict
+from django.core.exceptions import ImproperlyConfigured
 
 from django.db.models.query import QuerySet
 
@@ -35,8 +36,8 @@ class BlockingRouter(object):
         for name in apps:
             try:
                 self.add_app(name)
-            except Exception:
-                logger.exception("Failed to add app to router.")
+            except Exception as e:
+                raise ImproperlyConfigured("Cannot add app %s to router: %s" % (name, e))
         for name, conf in backends.iteritems():
             parsed_conf = copy.copy(conf)
             engine = parsed_conf.pop('ENGINE')


### PR DESCRIPTION
This change will result in an ImproperlyConfigured exception during startup
if there are any problems initializing the router, apps, or handlers.
Previously, these might not be noticed until the first request, and perhaps
not even then unless you were reading the logs to see the exceptions
logged.

What do folks think about this? It would have saved me several hours of debugging today due to a simple but silently ignored error.  

(Note: this is against the simplified handler loading branch, so needs to not be merged until after that.)
