### PR TITLE
Allow message tester submission via Enter button

### DIFF
--- a/rapidsms/contrib/httptester/templates/httptester/index.html
+++ b/rapidsms/contrib/httptester/templates/httptester/index.html
@@ -4,7 +4,7 @@
 
 {% block title %}Message Tester - {{ block.super }}{% endblock %}
 
-{% block extra_javascripts %}
+{% block extra_javascript %}
 <script type="text/javascript">
 	(function($) {
 		$(function() {


### PR DESCRIPTION
I think the previous version of the message tester allowed you to hit Enter to submit the message. I think this is a nice convenience feature and we should think about adding it to the current implementation.
