### PR TITLE
fixes a bug in the db router that doesn't properly iterate through the transmission groups

### DIFF
--- a/rapidsms/router/db/router.py
+++ b/rapidsms/router/db/router.py
@@ -54,20 +54,22 @@ class DatabaseRouter(BlockingRouter):
            a queryset of transmissions that all go with that
            backend, no more than ``batch_size`` each.
         """
-        start = 0
-        if batch_size is None:
-            batch_size = self._default_batch_size()
-        end = batch_size
         # divide transmissions by backend
         backends = transmissions.values_list('connection__backend_id',
                                              flat=True)
         for backend_id in backends.distinct():
             q = Q(connection__backend_id=backend_id)
             # filter down based on this backend and order by ID
-            transmissions = transmissions.filter(q).order_by('id')
+            transmissions_group = transmissions.filter(q).order_by('id')
+
+            start = 0
+            if batch_size is None:
+                batch_size = self._default_batch_size()
+            end = batch_size
+
             while True:
                 # divide transmissions into chunks of specified size
-                batch = transmissions[start:end]
+                batch = transmissions_group[start:end]
                 if not batch.exists():
                     # query returned no rows, so we've seen all transmissions
                     break


### PR DESCRIPTION
If you take a look at https://github.com/rapidsms/rapidsms/blob/develop/rapidsms/router/db/router.py#L67

You'll notice this:

``` python
transmissions = transmissions.filter(q).order_by('id')
```

The problem with this is that transmissions changes and during the next iteration, the method is unable to fetch the next transmission group. This problem only occurs when you're attempting to send bulk messages using different backends for the connections.

This pull request fixes that problem.
