### PR TITLE
Fix documentation re: outgoing phase return value

### DIFF
--- a/docs/topics/applications/index.rst
+++ b/docs/topics/applications/index.rst
@@ -175,7 +175,7 @@ is processed sequentially by the router's associated applications. However, the
 applications are called in reverse order with respect to the order they are
 called in ``BaseRouter.receive_incoming``, so the first application called to
 process an incoming message is the last application that is called to process
-an outgoing message. If any application returns ``True`` during the *outgoing*
+an outgoing message. If any application returns ``False`` during the *outgoing*
 phase, all further processing of the message will be aborted.
 
 The logic for the *outgoing* phase is defined in a method of the same name

--- a/docs/topics/router/index.rst
+++ b/docs/topics/router/index.rst
@@ -153,5 +153,5 @@ processes messages sequentially, in the order they are listed in
 :setting:`INSTALLED_APPS`. However, the applications are called in reverse
 order, so the first application called to process an incoming message is the
 last application that is called to process an outgoing message. If any
-application returns ``True`` during the *outgoing* phase, all further
+application returns ``False`` during the *outgoing* phase, all further
 processing of the message will be aborted.

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -227,7 +227,7 @@ class BlockingRouter(object):
                     continue_sending = func(msg)
                 except Exception:
                     logger.exception("Error while processing outgoing phase.")
-                # during any outgoing phase, an app can return True to
+                # during any outgoing phase, an app can return False to
                 # abort ALL further processing of this message
                 if continue_sending is False:
                     logger.warning("Message cancelled")


### PR DESCRIPTION
As it turns out, there are already 2 tests in the test suite which confirm the current behavior, so I didn't add any tests, just fixed the docs.

Refs rapidsms/rapidsms#417
