### PR TITLE
httptester: Allow international notation for originating number

### DIFF
--- a/rapidsms/contrib/httptester/forms.py
+++ b/rapidsms/contrib/httptester/forms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-
+import re
 from django import forms
 
 
@@ -39,6 +39,6 @@ class MessageForm(forms.Form):
     def clean_identity(self):
         if 'identity' in self.cleaned_data:
             identity = self.cleaned_data['identity'].strip()
-            if not identity.isnumeric():
-                raise ValidationError("Phone number must be all numeric")
+            if not re.match("^\+?\d+$", identity):
+                raise ValidationError("Phone number must be all numeric (or in international format)")
             return identity

--- a/rapidsms/contrib/httptester/tests.py
+++ b/rapidsms/contrib/httptester/tests.py
@@ -136,9 +136,12 @@ class ViewTest(RapidTest):
 class FormTest(ut2.TestCase):
     def test_clean_identity(self):
         # The form strips whitespace from the phone number, and does not
-        # accept non-numeric input
+        # accept non-numeric input (except for international notation)
         form = MessageForm({'identity': ' 123 '})
         self.assertTrue(form.is_valid(), msg=form.errors)
         self.assertEqual('123', form.cleaned_data['identity'])
+        form = MessageForm({'identity': ' +123 '})
+        self.assertTrue(form.is_valid(), msg=form.errors)
+        self.assertEqual('+123', form.cleaned_data['identity'])
         form = MessageForm({'identity': ' 1a23 '})
         self.assertFalse(form.is_valid())

--- a/rapidsms/contrib/httptester/urls.py
+++ b/rapidsms/contrib/httptester/urls.py
@@ -8,5 +8,5 @@ from . import views
 
 urlpatterns = patterns('',
     url(r"^$", views.generate_identity, name='httptester-index'),
-    url(r"^(?P<identity>\d+)/$", views.message_tester, name='httptester')
+    url(r"^(?P<identity>\+?\d+)/$", views.message_tester, name='httptester')
 )


### PR DESCRIPTION
Accepts an optional "+" prefix for originating phone numbers, to allow httptester to be used with applications handling identities in international notation.
