### PR TITLE
httptester: Add "Resend last message" button

### DIFF
--- a/rapidsms/contrib/httptester/storage.py
+++ b/rapidsms/contrib/httptester/storage.py
@@ -51,3 +51,7 @@ def clear_messages(identity):
 def clear_all_messages():
     """Forget all messages"""
     BackendMessage.objects.filter(name=BACKEND_NAME).delete()
+
+def resend_last_message(identity):
+    message = BackendMessage.objects.filter(name=BACKEND_NAME, direction="I").latest('date')
+    store_and_queue(identity, message.text)

--- a/rapidsms/contrib/httptester/templates/httptester/index.html
+++ b/rapidsms/contrib/httptester/templates/httptester/index.html
@@ -40,6 +40,9 @@
                     <div class="form-actions">
                         <button type="submit" class="btn btn-primary" id="send-btn" name="send-btn">Send</button>
                         <label for="send-btn">Send single or multiple messages</label>
+                        <button type="submit" class="btn btn-primary" id="resend-btn" name="resend-btn">Resend</button>
+                        <label for="resend-btn">Resends the last message</label>
+                        <hr>
                         <button type="submit" class="btn btn-primary" id="clear-btn" name="clear-btn">Clear</button>
                         <label for="clear-btn">Clear saved messages to/from this phone number</label>
                         <button type="submit" class="btn btn-primary" id="clear-all-btn" name="clear-all-btn">Clear all</button>

--- a/rapidsms/contrib/httptester/views.py
+++ b/rapidsms/contrib/httptester/views.py
@@ -57,6 +57,9 @@ def message_tester(request, identity):
             elif 'clear-btn' in request.POST:
                 storage.clear_messages(identity)
                 messages.add_message(request, messages.INFO, "Cleared %s messages" % identity)
+            elif 'resend-btn' in request.POST:
+                storage.resend_last_message(identity)
+                messages.add_message(request, messages.INFO, "Resend last message")
             else:
                 if "bulk" in request.FILES:
                     for line in request.FILES["bulk"]:


### PR DESCRIPTION
Scratching my own itch here, not so sure if this is something you want to pull:

In early developing, I found myself constantly copy & pasting the previous test mesage, either because something failed or because I needed to test the same message with different numbers, so I added a "resend" button.

The additional button makes the page a bit more bulky. An alternative implementation could have been to load the last message into the text field on GET and have all text selected when the field gets focus (so you can type a new message directly without having to delete the old one first).

So this was just a quick fix, but if you are interested in the general idea I can touch it up a bit.
