### PR TITLE
Get rid of uses of the deprecated 'msg.connection'

### DIFF
--- a/rapidsms/contrib/messagelog/app.py
+++ b/rapidsms/contrib/messagelog/app.py
@@ -9,15 +9,15 @@ from .models import Message
 class MessageLogApp(AppBase):
 
     def _log(self, direction, msg):
-        if not msg.contact and not msg.connection:
+        if not msg.connections:
             raise ValueError
         text = msg.raw_text if direction == Message.INCOMING else msg.text
         return Message.objects.create(
             date=timezone.now(),
             direction=direction,
             text=text,
-            contact=msg.contact,
-            connection=msg.connection,
+            contact=msg.connections[0].contact,
+            connection=msg.connections[0],
         )
 
     def parse(self, msg):

--- a/rapidsms/contrib/messagelog/tests/app.py
+++ b/rapidsms/contrib/messagelog/tests/app.py
@@ -25,8 +25,8 @@ class MessageLogAppTestBase(object):
         else:
             self.assertEqual(msg_obj.direction, Message.OUTGOING)
         self.assertEqual(msg_obj, msg.logger_msg)
-        self.assertEqual(msg_obj.contact, msg.contact)
-        self.assertEqual(msg_obj.connection, msg.connection)
+        self.assertEqual(msg_obj.contact, msg.connections[0].contact)
+        self.assertEqual(msg_obj.connection, msg.connections[0])
         self.assertEqual(msg_obj.text, msg.text)
 
     def test_message(self):

--- a/rapidsms/messages/outgoing.py
+++ b/rapidsms/messages/outgoing.py
@@ -42,4 +42,4 @@ class OutgoingMessage(MessageBase):
         ``rapidsms.router.send(text, connections)``.
         """
         from rapidsms.router import send
-        send(self.text, self.connection)
+        send(self.text, self.connections)

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -146,7 +146,7 @@ class BlockingRouter(object):
         """
         # Note: this method can't ever return False, but some subclass might
         # override it and use that feature.
-        logger.info("Incoming (%s): %s" % (msg.connection, msg.text))
+        logger.info("Incoming (%s): %s" % (msg.connections, msg.text))
 
         try:
             for phase in self.incoming_phases:


### PR DESCRIPTION
Closes #404 and #413
