### PR TITLE
Fixes for the docs and #439 

### DIFF
--- a/docs/topics/backends/custom.rst
+++ b/docs/topics/backends/custom.rst
@@ -72,7 +72,7 @@ would provide ``phone`` and ``message`` parameters.
 
 An URL pattern for this backend might look like::
 
-    from project_name.app_name.views import CustomHttpBackendView
+    from project_name.app_name.views import MyBackendView
 
     urlpatterns = patterns('',
         url(r'^backends/mybackend/$',

--- a/docs/topics/backends/custom.rst
+++ b/docs/topics/backends/custom.rst
@@ -84,7 +84,7 @@ A request to this backend might look like the following::
     >>> import urllib
     >>> import urllib2
     >>> data = urllib.urlencode({'phone': '1112223333', 'message': 'ping'})
-    >>> request = urllib2.urlopen(http://localhost:8000/backends/mybackend/', data)
+    >>> request = urllib2.urlopen('http://localhost:8000/backends/mybackend/', data)
     >>> request.code
     200
     >>> request.read()

--- a/rapidsms/contrib/handlers/handlers/keyword.py
+++ b/rapidsms/contrib/handlers/handlers/keyword.py
@@ -72,7 +72,8 @@ class KeywordHandler(BaseHandler):
                 $                # match all the way to the end
             """.format(keyword=cls.keyword)
 
-            return re.compile(prefix, re.IGNORECASE|re.VERBOSE)
+            return re.compile(prefix, re.IGNORECASE|re.VERBOSE|re.DOTALL)
+
         raise HandlerError('KeywordHandler must define a keyword.')
 
     @classmethod

--- a/rapidsms/contrib/handlers/tests/handlers.py
+++ b/rapidsms/contrib/handlers/tests/handlers.py
@@ -116,6 +116,14 @@ class TestKeywordHandler(RapidTest):
         self._check_dispatch('hello x , : ; sdf    ,:   ',
                              'x , : ; sdf    ,:   ')
 
+    def test_intermediate_newline(self):
+        """A newline in the middle of the text"""
+        self._check_dispatch('hello x \n y \n z')
+
+    def test_newline_just_after_keyword(self):
+        """A newline just after the keyword and before the text"""
+        self._check_dispatch('hello \n x y z')
+
 
 class TestPatternHandler(RapidTest):
     """Tests for rapidsms.contrib.handlers.handlers.pattern"""

--- a/rapidsms/contrib/handlers/tests/handlers.py
+++ b/rapidsms/contrib/handlers/tests/handlers.py
@@ -118,11 +118,11 @@ class TestKeywordHandler(RapidTest):
 
     def test_intermediate_newline(self):
         """A newline in the middle of the text"""
-        self._check_dispatch('hello x \n y \n z')
+        self._check_dispatch('hello x \n y \n z', 'x \n y \n z')
 
     def test_newline_just_after_keyword(self):
-        """A newline just after the keyword and before the text"""
-        self._check_dispatch('hello \n x y z')
+        """A newline just after the keyword and before the text is ignored"""
+        self._check_dispatch('hello \n x y z', 'x y z')
 
 
 class TestPatternHandler(RapidTest):


### PR DESCRIPTION
These commits fix small issues in the documentation and the issue #439 

As per suggestion given by @jthurner on the IRC: 
The fixes for #439 will mean that the *text* argument in ```handle()``` method will contain newlines if they are received. This might mean that someone's code which assumes no newlines in *text* argument, might break. Hence, we could have some kind of switchable behaviour which converts these newlines into whitespaces in the text argument, if required.

What do you guys think ?