### PR TITLE
Linking Outgoing message in the Database Router with the Database message

### DIFF
--- a/rapidsms/router/db/router.py
+++ b/rapidsms/router/db/router.py
@@ -89,6 +89,7 @@ class DatabaseRouter(BlockingRouter):
         if msg.in_response_to and hasattr(msg.in_response_to, 'dbm'):
             dbm.in_response_to = msg.in_response_to.dbm
         dbm.save()
+        msg.database_message = dbm
         for backend_id, trans in self.group_transmissions(dbm.transmissions):
             transmission_ids = list(trans.values_list('pk', flat=True))
             send_transmissions.delay(backend_id=backend_id,

--- a/rapidsms/router/db/tests.py
+++ b/rapidsms/router/db/tests.py
@@ -334,3 +334,14 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
         errored = Transmission.objects.filter(status='E')
         # only 1 of the transmissions should have a status of 'E' now
         self.assertEqual(1, errored.count())
+
+    def test_database_message_sent(self):
+        """ Database message should be marked as sent after a successful router.send(). """
+        connection = self.lookup_connections(['1111111111'])[0]
+        msg = self.send("test", connection)
+        database_message = msg.database_message
+
+        database_message.refresh_from_db()
+        self.assertEqual(database_message.status, 'S')
+        self.assertIsNotNone(database_message.sent)
+        self.assertEqual(database_message.direction, 'O')


### PR DESCRIPTION
When using Database Router as rapidsms router, at the backend_preparation, link the database message object with the Outgoing message, making possible to retrieve the message saved using the message object.

Now when you use:

``` python
from rapidsms import router
...
outgoing_message = router.send('Testing message', connections)
# Now you can get the database messages and transmissions
print outgoing_message.database_message.status
outgoing_message.database_message.transmissions.all()
```
