### PR TITLE
Allow from address configuration with Vumi

### DIFF
--- a/rapidsms/backends/vumi/outgoing.py
+++ b/rapidsms/backends/vumi/outgoing.py
@@ -30,6 +30,10 @@ class VumiBackend(BackendBase):
                         'metadata': {'rapidsms_msg_id': id_}})
         if len(identities) == 1 and 'external_id' in context:
             payload['in_reply_to'] = context['external_id']
+        # add endpoint and/or from_addr, if provided
+        for key in ['endpoint', 'from_addr']:
+            if key in context:
+                payload[key] = context[key]
         if self.sendsms_user and self.sendsms_pass:
             kwargs['auth'] = (self.sendsms_user, self.sendsms_pass)
         kwargs['data'] = json.dumps(payload)


### PR DESCRIPTION
Vumi can accept a JSON parameter to specify the 'From Address' of an outgoing message. The key can be either `from_addr` or `endpoint` (depending on Vumi's configuration). This PR allows those 2 keys to be passed on to Vumi.

Note: Currently, the `context` variable that gets to `VumiBackend.send` is not easily configurable, so it will require one more PR to get this fully working. Our current project has a way around that, but if desired I can add that type of configurability to rapidsms core. It would involve allowing `rapidsms.messages.outgoing.extra_backend_context` to take parameters.