### PR TITLE
Update database and celery routers to use modern task decorator

### DIFF
--- a/rapidsms/router/celery/tasks.py
+++ b/rapidsms/router/celery/tasks.py
@@ -1,4 +1,4 @@
-import celery
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from rapidsms.errors import MessageSendingError
 
@@ -6,7 +6,7 @@ from rapidsms.errors import MessageSendingError
 logger = get_task_logger(__name__)
 
 
-@celery.task
+@shared_task
 def receive_async(text, connection_id, message_id, fields):
     """Task used to send inbound message through router phases."""
     from rapidsms.models import Connection
@@ -25,7 +25,7 @@ def receive_async(text, connection_id, message_id, fields):
         raise
 
 
-@celery.task
+@shared_task
 def send_async(backend_name, id_, text, identities, context):
     """Task used to send outgoing messages to backends."""
     logger.debug('send_async: %s', text)

--- a/rapidsms/router/db/tasks.py
+++ b/rapidsms/router/db/tasks.py
@@ -1,4 +1,4 @@
-import celery
+from celery import shared_task
 from celery.utils.log import get_task_logger
 
 from django.utils.timezone import now
@@ -11,7 +11,7 @@ __all__ = ('receive_async', 'send_transmissions')
 logger = get_task_logger(__name__)
 
 
-@celery.task
+@shared_task
 def receive_async(message_id, fields):
     """Retrieve message from DB and pass to BlockingRouter for processing."""
     from rapidsms.router.db.models import Message
@@ -32,7 +32,7 @@ def receive_async(message_id, fields):
         dbm.set_status()
 
 
-@celery.task
+@shared_task
 def send_transmissions(backend_id, message_id, transmission_ids):
     """Send message to backend with provided transmissions. Retry if failed."""
     from rapidsms.models import Backend


### PR DESCRIPTION
The latest version of rapidsms does not work with the latest version of Celery. I've attached a simple patch to fix this.

@celery.task is deprecated and doesn't work in Celery 3.1.17. The
current way is to use @shared_task.

Thanks,

Logan
