### PR TITLE
Stop using django.utils.importlib as it's deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 env:
-  - TOXENV=py26-1.6.X,py27-1.6.X
+  - TOXENV=py27-1.6.X
   - TOXENV=py27-1.7.X,py33-1.7.X,py34-1.7.X
   - TOXENV=py27-1.8.X,py33-1.8.X,py34-1.8.X
   - TOXENV=py27-trunk,py33-trunk,py34-trunk

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ pygments_style = 'sphinx'
 #modindex_common_prefix = []
 
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/2.6', None),
+    'python': ('http://docs.python.org/', None),
     'django': ('https://django.readthedocs.org/en/1.4.X/', None),
 }
 

--- a/docs/developing/testing.rst
+++ b/docs/developing/testing.rst
@@ -66,14 +66,18 @@ together or specific ones::
 
 The available environments are:
 
- * ``py26-1.4.X`` - Test using Python 2.6 and Django 1.4.X
- * ``py26-1.5.X`` - Test using Python 2.6 and Django 1.5.X
- * ``py26-1.6.X`` - Test using Python 2.6 and Django 1.6.X
- * ``py27-1.4.X`` - Test using Python 2.7 and Django 1.4.x
- * ``py27-1.5.X`` - Test using Python 2.7 and Django 1.5.x
  * ``py27-1.6.X`` - Test using Python 2.7 and Django 1.6.x
  * ``py27-1.7.X`` - Test using Python 2.7 and Django 1.7.x
+ * ``py27-1.8.X`` - Test using Python 2.7 and Django 1.8.x
  * ``py27-trunk`` - Test using Python 2.7 and Django master
+ * ``py33-1.6.X`` - Test using Python 3.3 and Django 1.6.x
+ * ``py33-1.7.X`` - Test using Python 3.3 and Django 1.7.x
+ * ``py33-1.8.X`` - Test using Python 3.3 and Django 1.8.x
+ * ``py33-trunk`` - Test using Python 3.3 and Django master
+ * ``py34-1.6.X`` - Test using Python 3.4 and Django 1.6.x
+ * ``py34-1.7.X`` - Test using Python 3.4 and Django 1.7.x
+ * ``py34-1.8.X`` - Test using Python 3.4 and Django 1.8.x
+ * ``py34-trunk`` - Test using Python 3.4 and Django master
  * ``docs`` - Test building docs
  * ``flake8`` - Run flake8 style checker
  * ``coverage`` - Report coverage

--- a/rapidsms/utils/modules.py
+++ b/rapidsms/utils/modules.py
@@ -4,7 +4,7 @@ import os
 import sys
 import inspect
 
-from django.utils.importlib import import_module
+from importlib import import_module
 
 
 __all__ = ('import_class', 'import_module', 'try_import', 'find_python_files',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py26-1.6.X,
-          py27-1.6.X,
+envlist = py27-1.6.X,
           py27-1.7.X,
           py27-1.8.X,
           py27-trunk,
@@ -23,11 +22,6 @@ basepython = python2.7
 setenv = PYTHON_PATH = {toxinidir}
          DJANGO_SETTINGS_MODULE = tests.default
 commands = {envpython} run_tests.py {posargs}
-
-[testenv:py26-1.6.X]
-basepython = python2.6
-deps = django>=1.6,<1.7
-       {[default]deps}
 
 [testenv:py27-1.6.X]
 basepython = python2.7


### PR DESCRIPTION
This removes Python 2.6 support so we can use importlib instead of the deprecated django interface.

Python 2.7 was released 5 years ago and many other projects are dropping
support for earlier versions. (Including Django itself). If someone _has_ to use
an ancient version of python they can use an older version of Rapidsms.