### PR TITLE
Allow backends to specify failed messages

### DIFF
--- a/rapidsms/backends/base.py
+++ b/rapidsms/backends/base.py
@@ -45,12 +45,32 @@ class BackendBase(object):
         """
         Backend sending logic. The router will call this method for each
         outbound message. This method must be overridden by sub-classes.
-        Backends typically initiate HTTP requests from within this method. Any
-        exceptions raised here will be captured and logged by the selected
-        router.
+        Backends typically initiate HTTP requests from within this method.
 
         If multiple ``identities`` are provided, the message is intended for
         all recipients.
+
+        Any exceptions raised here will be captured and logged by the router. If
+        messages to some identities failed while others succeeded, you can
+        provide that information back to the router by adding a list of the
+        identities which failed in a ``failed_identities`` parameter on the
+        exception. If you do provide that parameter, then the router should assume
+        that all identities *not* listed in ``failed_identities`` were successfully
+        sent.
+
+        :Example:
+
+        .. code-block:: python
+
+         def send(self, id_, text, identities, context):
+             failures = []
+             for identity in identities:
+                 result = send_my_message(identity, text, context)
+                 if result == 'failed':
+                     failures.append(identity)
+             if failures:
+                 msg = '%d messages failed.' % len(failures)
+                 raise MessageSendingError(msg, failed_identities=failures)
 
         :param id\_: Message ID
         :param text: Message text

--- a/rapidsms/errors.py
+++ b/rapidsms/errors.py
@@ -8,6 +8,10 @@ class MessageSendingError(Exception):
     Where possible, a more specific exception should be raised, along
     with a descriptive message.
     """
+    def __init__(self, message='An error occurred during sending.', failed_identities=None):
+        # list of failed identities can optionally be attached
+        self.failed_identities = failed_identities or []
+        super(MessageSendingError, self).__init__(message)
 
 
 class NoRouterError(MessageSendingError):

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -281,9 +281,12 @@ class BlockingRouter(object):
         try:
             backend.send(id_=id_, text=text, identities=identities,
                          context=context)
-        except Exception:
+        except Exception as exc:
             msg = "%s encountered an error while sending." % backend_name
             logger.exception(msg)
+            if hasattr(exc, 'failed_identities') and exc.failed_identities:
+                # propagate failed_identities to caller
+                raise
             raise MessageSendingError(msg)
 
     def new_incoming_message(self, text, connections, class_=IncomingMessage,

--- a/rapidsms/router/blocking/tests/test_router.py
+++ b/rapidsms/router/blocking/tests/test_router.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+
 from rapidsms.tests import harness
 from rapidsms.router.blocking import BlockingRouter
 from rapidsms.messages.incoming import IncomingMessage
@@ -99,7 +100,7 @@ class RouterOutgoingPhases(harness.RapidTest):
         continue_sending = self.router.process_outgoing_phases(msg)
         self.assertFalse(continue_sending)
 
-    def test_proccessed_flag_set(self):
+    def test_processed_flag_set(self):
         """
         BaseMessage.processed should be set to True after
         outgoing phase processing.

--- a/rapidsms/router/db/tests.py
+++ b/rapidsms/router/db/tests.py
@@ -192,12 +192,13 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
 
     router_class = 'rapidsms.router.db.DatabaseRouter'
 
-    def create_trans(self, s1='Q', s2='Q'):
+    def create_trans(self, s1='Q', s2='Q', backend=None):
+        backend = backend or self.backend
         Connection.objects.bulk_create((
-            Connection(identity='1111111111', backend=self.backend),
-            Connection(identity='2222222222', backend=self.backend),
-            Connection(identity='3333333333', backend=self.backend),
-            Connection(identity='4444444444', backend=self.backend),
+            Connection(identity='1111111111', backend=backend),
+            Connection(identity='2222222222', backend=backend),
+            Connection(identity='3333333333', backend=backend),
+            Connection(identity='4444444444', backend=backend),
         ))
         dbm = Message.objects.create(text="test", direction="O")
         for connection in Connection.objects.order_by('id')[:2]:
@@ -207,11 +208,10 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
         ids = dbm.transmissions.order_by('id').values_list('id', flat=True)
         trans1 = dbm.transmissions.filter(id__in=ids[:2])
         trans2 = dbm.transmissions.filter(id__in=ids[2:])
-        return self.backend, dbm, trans1, trans2
+        return dbm, trans1, trans2
 
     def create_many_transmissions(self, num, backend=None):
-        if not backend:
-            backend = self.backend
+        backend = backend or self.backend
         # Create a message that will be sent to many connections
         message = Message.objects.create(text="test", direction="O")
         for i in range(num):
@@ -222,31 +222,31 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
     def test_send_successful_status(self):
         """Transmissions should be marked with S if no errors occured."""
         # create 2 batches (queued, queued)
-        backend, dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
-        send_transmissions(backend.pk, dbm.pk, t1.values_list('id', flat=True))
+        dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
+        send_transmissions(self.backend.pk, dbm.pk, t1.values_list('id', flat=True))
         status = t1.values_list('status', flat=True).distinct()[0]
         self.assertEqual('S', status)
 
     def test_send_successful_message_status(self):
         """Message object should be updated if all transmissions were sent."""
         # create 2 batches (sent, queued)
-        backend, dbm, t1, t2 = self.create_trans(s1='S', s2='Q')
-        send_transmissions(backend.pk, dbm.pk, t2.values_list('id', flat=True))
+        dbm, t1, t2 = self.create_trans(s1='S', s2='Q')
+        send_transmissions(self.backend.pk, dbm.pk, t2.values_list('id', flat=True))
         dbm = Message.objects.all()[0]
         self.assertEqual('S', dbm.status)
 
     def test_send_successful_message_status_previous_error(self):
         """Message should be marked E even if current batch sends."""
         # create 2 batches (error, queued)
-        backend, dbm, t1, t2 = self.create_trans(s1='E', s2='Q')
-        send_transmissions(backend.pk, dbm.pk, t2.values_list('id', flat=True))
+        dbm, t1, t2 = self.create_trans(s1='E', s2='Q')
+        send_transmissions(self.backend.pk, dbm.pk, t2.values_list('id', flat=True))
         dbm = Message.objects.all()[0]
         self.assertEqual('E', dbm.status)
 
     def test_group_transmissions(self):
         """Transmissions should be grouped by batch_size."""
         # create 2 batches (queued, queued)
-        backend, dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
+        dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
         router = DatabaseRouter()
         trans = list(router.group_transmissions(Transmission.objects.all(),
                                                 batch_size=2))
@@ -296,9 +296,9 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
         """If a transmission has already been sent, don't resend it.
         (This may occur during a retry, when some of the messages were sent and some failed)."""
         # create 2 batches (sent, queued)
-        backend, dbm, t1, t2 = self.create_trans(s1='S', s2='Q')
+        dbm, t1, t2 = self.create_trans(s1='S', s2='Q')
         both_transmisssion_sets = list(t1.values_list('id', flat=True)) + list(t2.values_list('id', flat=True))
-        send_transmissions(backend.pk, dbm.pk, both_transmisssion_sets)
+        send_transmissions(self.backend.pk, dbm.pk, both_transmisssion_sets)
         dbm = Message.objects.get()
         self.assertEqual('S', dbm.status)
         # only 2 messages should be sent, both from t2
@@ -309,9 +309,9 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
         )
 
     def test_all_transmissions_set_to_E_if_backend_sending_error(self):
-        backend, dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
         error_backend = RaisesBackend(self.get_router(), 'error_backend')
         self.backends['error_backend'] = {'ENGINE': RaisesBackend}
+        dbm, t1, t2 = self.create_trans(s1='Q', s2='Q', backend=error_backend.model)
         both_transmisssion_sets = list(t1.values_list('id', flat=True)) + list(t2.values_list('id', flat=True))
         with override_settings(INSTALLED_BACKENDS=self.backends):
             with self.assertRaises(MessageSendingError):
@@ -321,11 +321,12 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
         self.assertEqual(4, errored.count())
 
     def test_only_failed_transmissions_set_to_E(self):
-        # FailedIdentitiesBackend will fail any messages to an identity with a '1' in it
-        # create_trans creates 4 identities, only one of which has a '1' in it
-        backend, dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
+        # FailedIdentitiesBackend will fail any messages to an identity with a '1' in it.
+        # create_trans creates 4 identities, only one of which has a '1' in it, so we expect
+        # one failure.
         error_backend = FailedIdentitiesBackend(self.get_router(), 'error_backend')
         self.backends['error_backend'] = {'ENGINE': FailedIdentitiesBackend}
+        dbm, t1, t2 = self.create_trans(s1='Q', s2='Q', backend=error_backend.model)
         both_transmisssion_sets = list(t1.values_list('id', flat=True)) + list(t2.values_list('id', flat=True))
         with override_settings(INSTALLED_BACKENDS=self.backends):
             with self.assertRaises(MessageSendingError):

--- a/rapidsms/tests/harness/backend.py
+++ b/rapidsms/tests/harness/backend.py
@@ -1,4 +1,5 @@
 from rapidsms.backends.base import BackendBase
+from rapidsms.errors import MessageSendingError
 
 
 class MockBackend(BackendBase):
@@ -21,3 +22,12 @@ class RaisesBackend(BackendBase):
 
     def send(self, **kwargs):
         raise Exception('Error!')
+
+
+class FailedIdentitiesBackend(BackendBase):
+    """Backend that fails if there's a 1 in the identity."""
+
+    def send(self, id_, text, identities, context=None):
+        failures = [identity for identity in identities if '1' in identity]
+        if failures:
+            raise MessageSendingError(failed_identities=failures)

--- a/rapidsms/tests/harness/backend.py
+++ b/rapidsms/tests/harness/backend.py
@@ -17,7 +17,7 @@ class MockBackend(BackendBase):
 
 
 class RaisesBackend(BackendBase):
-    """Simple backend that stores sent messages."""
+    """Backend that always raises an error."""
 
     def send(self, **kwargs):
         raise Exception('Error!')


### PR DESCRIPTION
... and propagate that info to routers. This currently is only used by the DatabaseRouter to allow it to retry failures in a batch without duplicating messages to successful identities in that batch.

Closes #465