### PR TITLE
Add missing migrations for Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - TOXENV=py27-1.7.X,py33-1.7.X,py34-1.7.X
   - TOXENV=py27-1.8.X,py33-1.8.X,py34-1.8.X
   - TOXENV=py27-trunk,py33-trunk,py34-trunk
+  - TOXENV=py27-migrations,py34-migrations
   - TOXENV=docs
   - TOXENV=flake8
   - TOXENV=coverage

--- a/check_for_missing_migrations.sh
+++ b/check_for_missing_migrations.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+django-admin.py makemigrations --dry-run | grep 'No changes detected' || (echo 'There are changes which require migrations.' && exit 1)

--- a/rapidsms/backends/database/migrations/0003_auto_20150801_2140.py
+++ b/rapidsms/backends/database/migrations/0003_auto_20150801_2140.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('database', '0002_auto_20150710_1421'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='backendmessage',
+            name='direction',
+            field=models.CharField(db_index=True, max_length=1, choices=[('I', 'Incoming'), ('O', 'Outgoing')]),
+            preserve_default=True,
+        ),
+    ]

--- a/rapidsms/backends/database/models.py
+++ b/rapidsms/backends/database/models.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
+from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible

--- a/rapidsms/backends/kannel/migrations/0002_auto_20150801_2142.py
+++ b/rapidsms/backends/kannel/migrations/0002_auto_20150801_2142.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('kannel', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='deliveryreport',
+            name='message_id',
+            field=models.CharField(max_length=255, verbose_name='Message ID'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='deliveryreport',
+            name='sms_id',
+            field=models.CharField(max_length=36, verbose_name='SMS ID'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='deliveryreport',
+            name='smsc',
+            field=models.CharField(max_length=255, verbose_name='SMSC'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='deliveryreport',
+            name='status',
+            field=models.SmallIntegerField(choices=[(1, 'Delivery Success'), (2, 'Delivery Failure'), (4, 'Message Buffered'), (8, 'SMSC Submit'), (16, 'SMSC Reject')]),
+            preserve_default=True,
+        ),
+    ]

--- a/rapidsms/backends/kannel/models.py
+++ b/rapidsms/backends/kannel/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 
 

--- a/rapidsms/contrib/messagelog/migrations/0002_auto_20150801_2140.py
+++ b/rapidsms/contrib/messagelog/migrations/0002_auto_20150801_2140.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('messagelog', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='message',
+            name='direction',
+            field=models.CharField(max_length=1, choices=[('I', 'Incoming'), ('O', 'Outgoing')]),
+            preserve_default=True,
+        ),
+    ]

--- a/rapidsms/contrib/messagelog/models.py
+++ b/rapidsms/contrib/messagelog/models.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
+from __future__ import unicode_literals
 
 from django.core.exceptions import ValidationError
 from django.db import models

--- a/rapidsms/migrations/0004_auto_20150801_2138.py
+++ b/rapidsms/migrations/0004_auto_20150801_2138.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rapidsms', '0003_delete_backendmessage'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='contact',
+            name='language',
+            field=models.CharField(help_text='The language which this contact prefers to communicate in, as a W3C language tag. If this field is left blank, RapidSMS will default to the value in LANGUAGE_CODE.', max_length=6, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/rapidsms/models.py
+++ b/rapidsms/models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
-
+from __future__ import unicode_literals
 
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible

--- a/rapidsms/router/db/migrations/0002_auto_20150801_2142.py
+++ b/rapidsms/router/db/migrations/0002_auto_20150801_2142.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('db', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='message',
+            name='direction',
+            field=models.CharField(max_length=1, db_index=True, choices=[('I', 'Incoming'), ('O', 'Outgoing')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='message',
+            name='status',
+            field=models.CharField(max_length=1, db_index=True, choices=[('Q', 'Queued'), ('R', 'Received'), ('P', 'Processing'), ('S', 'Sent'), ('D', 'Delivered'), ('E', 'Errored')], default='Q'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='transmission',
+            name='status',
+            field=models.CharField(max_length=1, db_index=True, choices=[('Q', 'Queued'), ('R', 'Received'), ('P', 'Processing'), ('S', 'Sent'), ('D', 'Delivered'), ('E', 'Errored')]),
+            preserve_default=True,
+        ),
+    ]

--- a/rapidsms/router/db/models.py
+++ b/rapidsms/router/db/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,15 @@ envlist = py26-1.6.X,
           py34-1.7.X,
           py34-1.8.X,
           py34-trunk,
+          py27-migrations,
+          py34-migrations,
           docs,
           flake8,
           coverage
 
 [default]
-deps = -r{toxinidir}/tests/requirements/dev.txt
+deps = pip>7
+       -r{toxinidir}/tests/requirements/dev.txt
 
 [testenv]
 basepython = python2.7
@@ -83,6 +86,20 @@ deps = https://github.com/django/django/archive/stable/1.8.x.tar.gz
 basepython = python3.4
 deps = https://github.com/django/django/archive/master.tar.gz
        {[default]deps}
+
+[testenv:py27-migrations]
+basepython = python2.7
+deps = django
+       {[default]deps}
+setenv = {[testenv]setenv}
+commands = {toxinidir}/check_for_missing_migrations.sh
+
+[testenv:py34-migrations]
+basepython = python3.4
+deps = django
+       {[default]deps}
+setenv = {[testenv]setenv}
+commands = {toxinidir}/check_for_missing_migrations.sh
 
 [testenv:docs]
 basepython = python2.7


### PR DESCRIPTION
I started my first RapidSMS Python 3 project the other day and Django complained of missing migrations. This is because some of the field `help_text` and `choices` values were bytestrings, both in the models.py file and in the migration files. On Python3, those same strings are interpreted as Unicode strings, so Django thinks a migration is necessary. This PR includes 3 commits:

1. Add tox envs to detect this issue in the future.
2. Make sure all models use unicode strings.
3. Add migrations for those changes.