### PR TITLE
Quick hack to fix context processor error in django1.8

### DIFF
--- a/rapidsms/templatetags/paginator_tags.py
+++ b/rapidsms/templatetags/paginator_tags.py
@@ -16,7 +16,7 @@ register = template.Library()
 from rapidsms.conf import settings
 
 
-if "django.template.context_processors.request" not in settings.TEMPLATE_CONTEXT_PROCESSORS:
+if "django.template.context_processors.request" not in settings.TEMPLATES[0]['OPTIONS']['context_processors']:
     raise ImproperlyConfigured(
         "To use paginator tag, add 'django.template.context_processors.request' "
         "to TEMPLATE_CONTEXT_PROCESSORS"

--- a/rapidsms/templatetags/paginator_tags.py
+++ b/rapidsms/templatetags/paginator_tags.py
@@ -16,9 +16,9 @@ register = template.Library()
 from rapidsms.conf import settings
 
 
-if "django.core.context_processors.request" not in settings.TEMPLATE_CONTEXT_PROCESSORS:
+if "django.template.context_processors.request" not in settings.TEMPLATE_CONTEXT_PROCESSORS:
     raise ImproperlyConfigured(
-        "To use paginator tag, add 'django.core.context_processors.request' "
+        "To use paginator tag, add 'django.template.context_processors.request' "
         "to TEMPLATE_CONTEXT_PROCESSORS"
     )
 


### PR DESCRIPTION
Why hack?  
Assumes you are using django templates as the first backend,
Quick workaround without much thought -- there might be cleaner more flexible ways to do this