### PR TITLE
Work around importlib deprecation.

### DIFF
--- a/rapidsms/utils/modules.py
+++ b/rapidsms/utils/modules.py
@@ -4,7 +4,10 @@ import os
 import sys
 import inspect
 
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:
+    from django.utils.importlib import import_module
 
 
 __all__ = ('import_class', 'import_module', 'try_import', 'find_python_files',


### PR DESCRIPTION
Use python's importlib if available to avoid using django's importlib which
is deprecated.
