### PR TITLE
Replaced usages of the six module with the version from Django.

### DIFF
--- a/rapidsms/backends/kannel/forms.py
+++ b/rapidsms/backends/kannel/forms.py
@@ -1,4 +1,4 @@
-from six import string_types
+from django.utils.six import string_types
 from django import forms
 
 from rapidsms.backends.http.forms import BaseHttpForm

--- a/rapidsms/contrib/registration/tests.py
+++ b/rapidsms/contrib/registration/tests.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 from django.http import Http404, HttpRequest, HttpResponseRedirect, QueryDict
 from django.test import TestCase
 from mock import Mock, patch
-from six import BytesIO
+from django.utils.six import BytesIO
 
 from rapidsms.models import Connection, Contact
 from rapidsms.tests.harness import CreateDataMixin, LoginMixin

--- a/rapidsms/contrib/registration/views.py
+++ b/rapidsms/contrib/registration/views.py
@@ -3,7 +3,7 @@
 
 import csv
 from io import TextIOWrapper
-import six
+from django.utils import six
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required

--- a/rapidsms/router/api.py
+++ b/rapidsms/router/api.py
@@ -1,5 +1,5 @@
 import collections
-from six import string_types
+from django.utils.six import string_types
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -5,7 +5,7 @@ import logging
 import warnings
 import copy
 from collections import defaultdict
-from six import string_types
+from django.utils.six import string_types
 
 from django.db.models.query import QuerySet
 

--- a/rapidsms/tests/harness/base.py
+++ b/rapidsms/tests/harness/base.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
-from six import unichr
-from six.moves import xrange
+from django.utils.six import unichr
+from django.utils.six.moves import xrange
 import string
 import random
 from django.contrib.auth.models import User

--- a/rapidsms/tests/test_management.py
+++ b/rapidsms/tests/test_management.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from six.moves import StringIO
+from django.utils.six.moves import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase

--- a/rapidsms/utils.py
+++ b/rapidsms/utils.py
@@ -3,7 +3,7 @@
 
 import pytz
 from datetime import datetime
-from six import string_types
+from django.utils.six import string_types
 
 
 def empty_str(in_str):


### PR DESCRIPTION
Noticed when using the Django 1.9 branch that RapidSMS uses six, but it's not in the setup dependencies. Since Django comes with six (since v1.5), I simply replaced all the usages of six with the version included in Django.
