### PR TITLE
Issue with httptester in newer django releases

### DIFF
--- a/rapidsms/templates/django_tables2/bootstrap-tables.html
+++ b/rapidsms/templates/django_tables2/bootstrap-tables.html
@@ -1,5 +1,4 @@
 {% spaceless %}
-{% load cycle from future %}
 {% load django_tables2 %}
 {% load paginator_tags %}
 {% if table.page %}

--- a/rapidsms/templatetags/paginator_tags.py
+++ b/rapidsms/templatetags/paginator_tags.py
@@ -16,13 +16,6 @@ register = template.Library()
 from rapidsms.conf import settings
 
 
-if "django.core.context_processors.request" not in settings.TEMPLATE_CONTEXT_PROCESSORS:
-    raise ImproperlyConfigured(
-        "To use paginator tag, add 'django.core.context_processors.request' "
-        "to TEMPLATE_CONTEXT_PROCESSORS"
-    )
-
-
 @register.inclusion_tag("rapidsms/templatetags/paginator.html", takes_context=True)
 def paginator(context, page, prefix=""):
     """Paginator Template Tag


### PR DESCRIPTION
The template loads cycle from future which is no longer supported in the latest django releases.