### PR TITLE
Support Django 1.11 and drop older versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-dist: trusty
 sudo: false
 python:
   - 3.5

--- a/rapidsms/backends/http/tests.py
+++ b/rapidsms/backends/http/tests.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.conf.urls import url
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from rapidsms.tests.harness import RapidTest
 from rapidsms.backends.http import views

--- a/rapidsms/backends/kannel/outgoing.py
+++ b/rapidsms/backends/kannel/outgoing.py
@@ -2,7 +2,7 @@ import copy
 import requests
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rapidsms.backends.base import BackendBase
 
 

--- a/rapidsms/backends/kannel/tests.py
+++ b/rapidsms/backends/kannel/tests.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.timezone import now
 from django.test.utils import override_settings
 

--- a/rapidsms/backends/vumi/tests.py
+++ b/rapidsms/backends/vumi/tests.py
@@ -2,7 +2,7 @@ import json
 from mock import patch
 
 from django.test import TestCase
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 
 from rapidsms.backends.vumi.outgoing import VumiBackend

--- a/rapidsms/conf.py
+++ b/rapidsms/conf.py
@@ -14,5 +14,5 @@ overriden by the project author in the top-level ``settings.py``.
 
 try:
     from djappsettings import settings
-except:
+except ImportError:
     from django.conf import settings  # noqa

--- a/rapidsms/contrib/httptester/tests.py
+++ b/rapidsms/contrib/httptester/tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from mock import patch
 from six import BytesIO

--- a/rapidsms/contrib/httptester/views.py
+++ b/rapidsms/contrib/httptester/views.py
@@ -6,7 +6,7 @@ from random import randint
 from django.contrib import messages
 
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, redirect
 
@@ -76,7 +76,7 @@ def message_tester(request, identity):
         form = forms.MessageForm({"identity": identity})
 
     messages_table = MessageTable(storage.get_messages(),
-                                  template="httptester/table.html")
+                                  template_name="httptester/table.html")
     RequestConfig(request,
                   paginate={"per_page": settings.PAGINATOR_OBJECTS_PER_PAGE})\
         .configure(messages_table)

--- a/rapidsms/contrib/messagelog/migrations/0001_initial.py
+++ b/rapidsms/contrib/messagelog/migrations/0001_initial.py
@@ -18,8 +18,8 @@ class Migration(migrations.Migration):
                 ('direction', models.CharField(max_length=1, choices=[(b'I', b'Incoming'), (b'O', b'Outgoing')])),
                 ('date', models.DateTimeField()),
                 ('text', models.TextField()),
-                ('connection', models.ForeignKey(blank=True, to='rapidsms.Connection', null=True)),
-                ('contact', models.ForeignKey(blank=True, to='rapidsms.Contact', null=True)),
+                ('connection', models.ForeignKey(blank=True, to='rapidsms.Connection', null=True, on_delete=models.CASCADE)),
+                ('contact', models.ForeignKey(blank=True, to='rapidsms.Contact', null=True, on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/rapidsms/contrib/messagelog/models.py
+++ b/rapidsms/contrib/messagelog/models.py
@@ -18,8 +18,8 @@ class Message(models.Model):
         (OUTGOING, "Outgoing"),
     )
 
-    contact = models.ForeignKey(Contact, blank=True, null=True)
-    connection = models.ForeignKey(Connection, blank=True, null=True)
+    contact = models.ForeignKey(Contact, blank=True, null=True, on_delete=models.CASCADE)
+    connection = models.ForeignKey(Connection, blank=True, null=True, on_delete=models.CASCADE)
     direction = models.CharField(max_length=1, choices=DIRECTION_CHOICES)
     date = models.DateTimeField()
     text = models.TextField()

--- a/rapidsms/contrib/messagelog/views.py
+++ b/rapidsms/contrib/messagelog/views.py
@@ -15,9 +15,9 @@ from django_tables2 import RequestConfig
 def message_log(request):
     qset = Message.objects.all()
     qset = qset.select_related('contact', 'connection__backend')
-    template = "django_tables2/bootstrap-tables.html"
+    template_name = "django_tables2/bootstrap-tables.html"
 
-    messages_table = MessageTable(qset, template=template)
+    messages_table = MessageTable(qset, template_name=template_name)
 
     paginate = {"per_page": settings.PAGINATOR_OBJECTS_PER_PAGE}
     RequestConfig(request, paginate=paginate).configure(messages_table)

--- a/rapidsms/contrib/messaging/tests/test_views.py
+++ b/rapidsms/contrib/messaging/tests/test_views.py
@@ -3,7 +3,7 @@
 
 import mock
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from rapidsms.tests.harness import RapidTest
 

--- a/rapidsms/contrib/messaging/views.py
+++ b/rapidsms/contrib/messaging/views.py
@@ -31,5 +31,5 @@ def send(request):
                 return HttpResponse(msg)
         else:
             return HttpResponseBadRequest(str(form.errors))
-    except:
+    except Exception:
         return HttpResponse("Unable to send message.", status=500)

--- a/rapidsms/contrib/registration/tests.py
+++ b/rapidsms/contrib/registration/tests.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpRequest, HttpResponseRedirect, QueryDict
 from django.test import TestCase
 from mock import Mock, patch
@@ -68,7 +68,7 @@ class TestViews(TestCase, CreateDataMixin, LoginMixin):
             views.registration(request)
         context = render.call_args[0][2]
         table = context["contacts_table"]
-        self.assertEqual(len(self.contacts), len(list(table.data.queryset)))
+        self.assertEqual(len(self.contacts), len(list(table.data)))
 
     def test_registration_render(self):
         # render actually works (django_tables2 and all)

--- a/rapidsms/contrib/registration/views.py
+++ b/rapidsms/contrib/registration/views.py
@@ -7,7 +7,7 @@ import six
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
@@ -25,7 +25,7 @@ from rapidsms.conf import settings
 def registration(request):
     contacts_table = ContactTable(
         Contact.objects.all().prefetch_related('connection_set'),
-        template="django_tables2/bootstrap-tables.html")
+        template_name="django_tables2/bootstrap-tables.html")
 
     paginate = {"per_page": settings.PAGINATOR_OBJECTS_PER_PAGE}
     RequestConfig(request, paginate=paginate).configure(contacts_table)
@@ -100,7 +100,7 @@ def contact_bulk_add(request):
         for i, row in enumerate(reader, start=1):
             try:
                 name, backend_name, identity = row
-            except:
+            except ValueError:
                 return render(request, 'registration/bulk_form.html', {
                     "bulk_form": bulk_form,
                     "csv_errors": "Could not unpack line " + str(i),
@@ -108,7 +108,7 @@ def contact_bulk_add(request):
             contact = Contact.objects.create(name=name)
             try:
                 backend = Backend.objects.get(name=backend_name)
-            except:
+            except Backend.DoesNotExist:
                 return render(request, 'registration/bulk_form.html', {
                     "bulk_form": bulk_form,
                     "csv_errors": "Could not find Backend.  Line: " + str(i),

--- a/rapidsms/migrations/0001_initial.py
+++ b/rapidsms/migrations/0001_initial.py
@@ -54,7 +54,7 @@ class Migration(migrations.Migration):
                 ('identity', models.CharField(max_length=100)),
                 ('created_on', models.DateTimeField(auto_now_add=True)),
                 ('modified_on', models.DateTimeField(auto_now=True)),
-                ('backend', models.ForeignKey(to='rapidsms.Backend')),
+                ('backend', models.ForeignKey(to='rapidsms.Backend', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -78,7 +78,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='connection',
             name='contact',
-            field=models.ForeignKey(blank=True, to='rapidsms.Contact', null=True),
+            field=models.ForeignKey(blank=True, to='rapidsms.Contact', null=True, on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(

--- a/rapidsms/models.py
+++ b/rapidsms/models.py
@@ -153,12 +153,12 @@ class Contact(ContactBase):
 class ConnectionBase(models.Model):
     #: foreign key to this connection's
     #: :py:class:`~rapidsms.backends.base.BackendBase`
-    backend = models.ForeignKey(Backend)
+    backend = models.ForeignKey(Backend, on_delete=models.CASCADE)
     #: unique identifier for this connection on this backend (e.g. phone
     #: number, email address, IRC nick, etc.)
     identity = models.CharField(max_length=100)
     #: (optional) associated :py:class:`~rapidsms.models.Contact`
-    contact = models.ForeignKey(Contact, null=True, blank=True)
+    contact = models.ForeignKey(Contact, null=True, blank=True, on_delete=models.CASCADE)
     #: when this connection was created
     created_on = models.DateTimeField(auto_now_add=True)
     #: when this connection was last modified

--- a/rapidsms/router/celery/tests.py
+++ b/rapidsms/router/celery/tests.py
@@ -45,7 +45,7 @@ class CeleryRouterTest(harness.DatabaseBackendMixin, TestCase):
         with override_settings(INSTALLED_BACKENDS=backends):
             try:
                 send_async("backend", "1234", "hello", ["1112223333"], {})
-            except:
+            except Exception:
                 self.fail("Sending exceptions should be caught within task")
 
 

--- a/rapidsms/router/db/migrations/0001_initial.py
+++ b/rapidsms/router/db/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('direction', models.CharField(db_index=True, max_length=1, choices=[(b'I', b'Incoming'), (b'O', b'Outgoing')])),
                 ('text', models.TextField()),
                 ('external_id', models.CharField(max_length=1024, blank=True)),
-                ('in_response_to', models.ForeignKey(related_name=b'responses', blank=True, to='db.Message', null=True)),
+                ('in_response_to', models.ForeignKey(related_name=b'responses', blank=True, to='db.Message', null=True, on_delete=models.CASCADE)),
             ],
             options={
             },
@@ -38,8 +38,8 @@ class Migration(migrations.Migration):
                 ('updated', models.DateTimeField(db_index=True, auto_now=True, null=True)),
                 ('sent', models.DateTimeField(null=True, blank=True)),
                 ('delivered', models.DateTimeField(null=True, blank=True)),
-                ('connection', models.ForeignKey(related_name=b'transmissions', to='rapidsms.Connection')),
-                ('message', models.ForeignKey(related_name=b'transmissions', to='db.Message')),
+                ('connection', models.ForeignKey(related_name=b'transmissions', to='rapidsms.Connection', on_delete=models.CASCADE)),
+                ('message', models.ForeignKey(related_name=b'transmissions', to='db.Message', on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/rapidsms/router/db/models.py
+++ b/rapidsms/router/db/models.py
@@ -44,7 +44,7 @@ class Message(models.Model):
     external_id = models.CharField(max_length=1024, blank=True)
     #: Optional. Foreign key to ``Message`` that generated this reply.
     in_response_to = models.ForeignKey('self', related_name='responses',
-                                       null=True, blank=True)
+                                       null=True, blank=True, on_delete=models.CASCADE)
 
     class Meta:
         app_label = 'db'
@@ -79,9 +79,9 @@ class Message(models.Model):
 @python_2_unicode_compatible
 class Transmission(models.Model):
     #: Required. Foreign key to associated ``Message``.
-    message = models.ForeignKey(Message, related_name='transmissions')
+    message = models.ForeignKey(Message, related_name='transmissions', on_delete=models.CASCADE)
     #: Required. Foreign key to associated ``Connection``.
-    connection = models.ForeignKey(Connection, related_name='transmissions')
+    connection = models.ForeignKey(Connection, related_name='transmissions', on_delete=models.CASCADE)
     #: Required. See :ref:`message-status-values`.
     status = models.CharField(max_length=1, choices=STATUS_CHOICES,
                               db_index=True)

--- a/rapidsms/tests/test_paginator.py
+++ b/rapidsms/tests/test_paginator.py
@@ -1,5 +1,5 @@
 from django.core.paginator import Paginator
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django.test.client import RequestFactory
 

--- a/rapidsms/tests/test_views.py
+++ b/rapidsms/tests/test_views.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.contrib.auth.models import User
 from django.test import TestCase
 

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,10 @@ setup(
 
     install_requires=[
         "requests>=1.2.0",
-        "django-tables2==1.0.*",
+        "django-tables2==1.21.*",
         "djappsettings>=0.4.0",
         "django-selectable>=0.7.0",
+        "six",
     ],
 
     packages=find_packages(),

--- a/tests/default.py
+++ b/tests/default.py
@@ -65,7 +65,7 @@ LOGGING = {
     }
 }
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -106,7 +106,6 @@ TEMPLATES = [
             'loaders': [
                 'django.template.loaders.filesystem.Loader',
                 'django.template.loaders.app_directories.Loader',
-                'django.template.loaders.eggs.Loader',
             ]
         },
     },

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -6,7 +6,7 @@ from rapidsms import views as rapidsms_views
 admin.autodiscover()
 
 urlpatterns = (
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 
     # RapidSMS core URLs
     url(r'^account/', include('rapidsms.urls.login_logout')),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35,py36}-dj111,
+envlist = {py27,py34,py35}-dj111,
           {py27,py35}-migrations,
           docs,
           flake8,
@@ -14,7 +14,6 @@ basepython =
      py27: python2.7
      py34: python3.4
      py35: python3.5
-     py36: python3.6
 deps =
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-{dj18,dj19,dj110},
+envlist = {py27,py34,py35,py36}-dj111,
           {py27,py35}-migrations,
           docs,
           flake8,
@@ -14,27 +14,25 @@ basepython =
      py27: python2.7
      py34: python3.4
      py35: python3.5
+     py36: python3.6
 deps =
-    dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
-    dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<2.0
     dj20: Django>=2.0,<2.1
     {[default]deps}
 setenv = PYTHON_PATH = {toxinidir}
          DJANGO_SETTINGS_MODULE = tests.default
-commands = {envpython} run_tests.py {posargs}
+commands = {envpython} -Wd run_tests.py {posargs}
 
 [testenv:py27-migrations]
 basepython = python2.7
-deps = Django>=1.10,<1.11
+deps = Django>=1.11,<2.0
        {[default]deps}
 setenv = {[testenv]setenv}
 commands = {toxinidir}/check_for_missing_migrations.sh
 
 [testenv:py35-migrations]
 basepython = python3.5
-deps = Django>=1.10,<1.11
+deps = Django>=1.11,<2.0
        {[default]deps}
 setenv = {[testenv]setenv}
 commands = {toxinidir}/check_for_missing_migrations.sh
@@ -42,20 +40,20 @@ commands = {toxinidir}/check_for_missing_migrations.sh
 [testenv:docs]
 basepython = python2.7
 deps = Sphinx>=1.3,<1.4
-       Django>=1.10,<1.11
+       Django>=1.11,<2.0
        {[default]deps}
 commands =
     {envbindir}/sphinx-build -a -n -W -b html -d docs/_build/doctrees docs docs/_build/html
 
 [testenv:flake8]
 basepython = python3.5
-deps = flake8>=3.3,<3.4
+deps = flake8
 commands = flake8 rapidsms
 
 [testenv:coverage]
 basepython = python3.5
 commands = coverage run run_tests.py
            coverage report -m --fail-under=85
-deps = coverage>=4.4,<4.5
-       Django>=1.10,<1.11
+deps = coverage
+       Django>=1.11,<2.0
        {[default]deps}


### PR DESCRIPTION
This will give us a version that supports Django 1.11 LTS, with minimal changes from the previous version that supports 1.8 thru 1.10. Once this is released, I'll go through and remove a bunch of old deprecated things and add 2.0 support.