### PR TITLE
An update for Django 1.11 compatibility 

### DIFF
--- a/rapidsms/views.py
+++ b/rapidsms/views.py
@@ -4,17 +4,16 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import login as django_login
 from django.contrib.auth.views import logout as django_logout
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.views.decorators.http import require_GET
 
 
 @login_required
 @require_GET
-def dashboard(req):
-    return render_to_response(
-        "dashboard.html",
-        context_instance=RequestContext(req))
+def dashboard(request):
+    return render(request,
+        "dashboard.html")
 
 
 def login(req, template_name="rapidsms/login.html"):


### PR DESCRIPTION
This PR makes RapidSMS compatible with Django 1.11 by removing the deprecated `context_instance` arg and using the more up-to-date `render` function: https://docs.djangoproject.com/en/1.11/topics/http/shortcuts/#render-to-response