### PR TITLE
Add DB index to Connection.identity

### DIFF
--- a/rapidsms/models.py
+++ b/rapidsms/models.py
@@ -156,7 +156,7 @@ class ConnectionBase(models.Model):
     backend = models.ForeignKey(Backend, on_delete=models.CASCADE)
     #: unique identifier for this connection on this backend (e.g. phone
     #: number, email address, IRC nick, etc.)
-    identity = models.CharField(max_length=100)
+    identity = models.CharField(max_length=100, db_index=True)
     #: (optional) associated :py:class:`~rapidsms.models.Contact`
     contact = models.ForeignKey(Contact, null=True, blank=True, on_delete=models.CASCADE)
     #: when this connection was created


### PR DESCRIPTION
This change adds an index to `Connection.identity`.  There is already a compound index on `(backend, identity)`, but our application (and potentially many others) filter only on `identity` which cannot take advantage of this index.

This change should improve the performance of these queries for all users.  We have been using an equivalent manually added index in our application with success.