### PR TITLE
Support Django2.2/3.2, Python3.7/8/9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 python:
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install tox-travis
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ dist: xenial
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.6"
   - "3.7"
+  - "3.8"
 install:
   - pip install tox-travis
   - pip install coveralls

--- a/rapidsms/apps/__init__.py
+++ b/rapidsms/apps/__init__.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class RapidsmsConfig(AppConfig):
+
+    name = "rapidsms"
+    default_auto_field = "django.db.models.AutoField"

--- a/rapidsms/apps/base.py
+++ b/rapidsms/apps/base.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.utils.encoding import python_2_unicode_compatible
-
 from ..utils.modules import try_import, get_class
 
 
-@python_2_unicode_compatible
 class AppBase(object):
     """
     """

--- a/rapidsms/backends/base.py
+++ b/rapidsms/backends/base.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.utils.encoding import python_2_unicode_compatible
-
 from rapidsms.utils.modules import import_class
 
 
-@python_2_unicode_compatible
 class BackendBase(object):
     """Base class for outbound backend functionality."""
 

--- a/rapidsms/backends/database/models.py
+++ b/rapidsms/backends/database/models.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 
 INCOMING = 'I'
@@ -15,7 +14,6 @@ DIRECTION_CHOICES = (
 )
 
 
-@python_2_unicode_compatible
 class BackendMessage(models.Model):
     name = models.CharField(max_length=255)
     date = models.DateTimeField(auto_now_add=True)

--- a/rapidsms/backends/http/tests.py
+++ b/rapidsms/backends/http/tests.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 from django.test.utils import override_settings
-from django.conf.urls import url
-from django.urls import reverse
+from django.urls import path, reverse
 
 from rapidsms.tests.harness import RapidTest
 from rapidsms.backends.http import views
@@ -16,10 +15,10 @@ class CustomHttpBackend(views.GenericHttpBackendView):
 
 
 urlpatterns = (
-    url(r"^backend/http/$",
+    path("backend/http/",
         views.GenericHttpBackendView.as_view(backend_name='http-backend'),
         name='http-backend'),
-    url(r"^backend/http-custom/$",
+    path("backend/http-custom/",
         CustomHttpBackend.as_view(),
         name='custom-http-backend'),
 )
@@ -116,9 +115,9 @@ class HttpViewTest(RapidTest):
         message = self.inbound[0]
         self.assertEqual(data['text'], message.text)
         self.assertEqual(data['identity'],
-                         message.connection.identity)
+                         message.connections[0].identity)
         self.assertEqual('http-backend',
-                         message.connection.backend.name)
+                         message.connections[0].backend.name)
 
     def test_valid_post_message_backend_name(self):
         """Created message/connection should be from custom http backend"""
@@ -126,4 +125,4 @@ class HttpViewTest(RapidTest):
         self.client.post(self.custom_http_backend_url, data)
         message = self.inbound[0]
         self.assertEqual('custom-http-backend',
-                         message.connection.backend.name)
+                         message.connections[0].backend.name)

--- a/rapidsms/backends/kannel/forms.py
+++ b/rapidsms/backends/kannel/forms.py
@@ -1,4 +1,3 @@
-from six import string_types
 from django import forms
 
 from rapidsms.backends.http.forms import BaseHttpForm
@@ -16,7 +15,7 @@ class KannelForm(BaseHttpForm):
         # have a unicode string
         charset = self.cleaned_data.get('charset', None)
         text = self.cleaned_data['text']
-        if charset and not isinstance(text, string_types):
+        if charset and not isinstance(text, str):
             text = text.decode(charset)
         return text
 

--- a/rapidsms/backends/kannel/tests.py
+++ b/rapidsms/backends/kannel/tests.py
@@ -60,9 +60,9 @@ class KannelViewTest(RapidTest):
         message = self.inbound[0]
         self.assertEqual(data['text'], message.text)
         self.assertEqual(data['id'],
-                         message.connection.identity)
+                         message.connections[0].identity)
         self.assertEqual('kannel-backend',
-                         message.connection.backend.name)
+                         message.connections[0].backend.name)
 
 
 @override_settings(ROOT_URLCONF='rapidsms.backends.kannel.urls')
@@ -91,7 +91,7 @@ class KannelSendTest(CreateDataMixin, TestCase):
                          data['username'])
         self.assertEqual(config['sendsms_params']['password'],
                          data['password'])
-        self.assertEqual(message.connection.identity, data['to'])
+        self.assertEqual(message.connections[0].identity, data['to'])
         self.assertEqual(config['coding'], data['coding'])
         self.assertEqual(config['charset'], data['charset'])
         self.assertEqual(message.text, data['text'].decode(data['charset']))

--- a/rapidsms/backends/kannel/urls.py
+++ b/rapidsms/backends/kannel/urls.py
@@ -1,13 +1,13 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from rapidsms.backends.kannel import views
 
 
 urlpatterns = (
-    url(r'^account/', include('rapidsms.urls.login_logout')),
-    url(r"^delivery-report/$",
+    path('account/', include('rapidsms.urls.login_logout')),
+    path('delivery-report/',
         views.DeliveryReportView.as_view(),
-        name="kannel-delivery-report"),
-    url(r"^backend/kannel/$",
+        name='kannel-delivery-report'),
+    path('backend/kannel/',
         views.KannelBackendView.as_view(backend_name='kannel-backend'),
         name='kannel-backend'),
 )

--- a/rapidsms/backends/vumi/tests.py
+++ b/rapidsms/backends/vumi/tests.py
@@ -104,9 +104,9 @@ class VumiViewTest(RapidTest):
         message = self.inbound[0]
         self.assertEqual(self.valid_data['content'], message.text)
         self.assertEqual(self.valid_data['from_addr'],
-                         message.connection.identity)
+                         message.connections[0].identity)
         self.assertEqual('vumi-backend',
-                         message.connection.backend.name)
+                         message.connections[0].backend.name)
 
     def test_blank_message_is_valid(self):
         """Blank messages should be considered valid."""

--- a/rapidsms/backends/vumi/urls.py
+++ b/rapidsms/backends/vumi/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from rapidsms.backends.vumi import views
 
 
 urlpatterns = (
-    url(r'^account/', include('rapidsms.urls.login_logout')),
-    url(r"^backend/vumi/$",
+    path('account/', include('rapidsms.urls.login_logout')),
+    path('backend/vumi/',
         views.VumiBackendView.as_view(backend_name='vumi-backend'),
         name='vumi-backend'),
 )

--- a/rapidsms/contrib/httptester/tests.py
+++ b/rapidsms/contrib/httptester/tests.py
@@ -3,7 +3,7 @@
 from django.urls import reverse
 from django.test import TestCase
 from mock import patch
-from six import BytesIO
+from io import BytesIO
 
 from rapidsms.backends.database.models import INCOMING
 from rapidsms.contrib.httptester.forms import MessageForm

--- a/rapidsms/contrib/httptester/urls.py
+++ b/rapidsms/contrib/httptester/urls.py
@@ -2,11 +2,11 @@
 # vim: ai ts=4 sts=4 et sw=4
 
 
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 
 urlpatterns = (
-    url(r"^$", views.generate_identity, name='httptester-index'),
-    url(r"^(?P<identity>\d+)/$", views.message_tester, name='httptester')
+    path("", views.generate_identity, name='httptester-index'),
+    path("(<int:identity>/", views.message_tester, name='httptester')
 )

--- a/rapidsms/contrib/httptester/urls.py
+++ b/rapidsms/contrib/httptester/urls.py
@@ -8,5 +8,5 @@ from . import views
 
 urlpatterns = (
     path("", views.generate_identity, name='httptester-index'),
-    path("(<int:identity>/", views.message_tester, name='httptester')
+    path("<int:identity>/", views.message_tester, name='httptester')
 )

--- a/rapidsms/contrib/messagelog/models.py
+++ b/rapidsms/contrib/messagelog/models.py
@@ -4,12 +4,10 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from rapidsms.models import Contact, Connection
 
 
-@python_2_unicode_compatible
 class Message(models.Model):
     INCOMING = "I"
     OUTGOING = "O"

--- a/rapidsms/contrib/messagelog/urls.py
+++ b/rapidsms/contrib/messagelog/urls.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 
 urlpatterns = (
-    url(r'^$', views.message_log, name="message_log"),
+    path('', views.message_log, name="message_log"),
 )

--- a/rapidsms/contrib/messaging/tests/test_forms.py
+++ b/rapidsms/contrib/messaging/tests/test_forms.py
@@ -49,4 +49,4 @@ class TestMessagingForm(RapidTest):
         self.assertTrue(form.is_valid())
         message = form.send()
         self.assertEqual(message.text, self.message)
-        self.assertEqual(message.connection, self.connection)
+        self.assertEqual(message.connections[0], self.connection)

--- a/rapidsms/contrib/messaging/urls.py
+++ b/rapidsms/contrib/messaging/urls.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 
 urlpatterns = (
-    url(r'^$', views.messaging, name='messaging'),
-    url(r'^send/$', views.send, name='send_message'),
+    path('', views.messaging, name='messaging'),
+    path('send/', views.send, name='send_message'),
 )

--- a/rapidsms/contrib/registration/handlers/language.py
+++ b/rapidsms/contrib/registration/handlers/language.py
@@ -18,7 +18,7 @@ class LanguageHandler(KeywordHandler):
         self.respond("To set your language, send LANGUAGE <CODE>")
 
     def handle(self, text):
-        if self.msg.connection.contact is None:
+        if self.msg.connections[0].contact is None:
             return self.respond_error(
                 "You must JOIN or REGISTER yourself before you can " +
                 "set your language preference.")
@@ -28,8 +28,8 @@ class LanguageHandler(KeywordHandler):
             if t != code.lower() and t != name.lower():
                 continue
 
-            self.msg.connection.contact.language = code
-            self.msg.connection.contact.save()
+            self.msg.connections[0].contact.language = code
+            self.msg.connections[0].contact.save()
 
             return self.respond(
                 "I will speak to you in %(language)s." % {

--- a/rapidsms/contrib/registration/handlers/register.py
+++ b/rapidsms/contrib/registration/handlers/register.py
@@ -30,8 +30,8 @@ class RegisterHandler(KeywordHandler):
 
     def handle(self, text):
         contact = Contact.objects.create(name=text)
-        self.msg.connection.contact = contact
-        self.msg.connection.save()
+        self.msg.connections[0].contact = contact
+        self.msg.connections[0].save()
 
         self.respond(
             "Thank you for registering, %(name)s!" % {'name': contact.name})

--- a/rapidsms/contrib/registration/tests.py
+++ b/rapidsms/contrib/registration/tests.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from django.http import Http404, HttpRequest, HttpResponseRedirect, QueryDict
 from django.test import TestCase
 from mock import Mock, patch
-from six import BytesIO
+from io import BytesIO
 
 from rapidsms.models import Connection, Contact
 from rapidsms.tests.harness import CreateDataMixin, LoginMixin

--- a/rapidsms/contrib/registration/urls.py
+++ b/rapidsms/contrib/registration/urls.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 
 urlpatterns = (
-    url(r'^$', views.registration, name="registration"),
-    url(r'^contact/add/$', views.contact, name="registration_contact_add"),
-    url(r'^contact/bulk_add/$', views.contact_bulk_add, name="registration_bulk_add"),
-    url(r'^(?P<pk>\d+)/edit/$', views.contact, name="registration_contact_edit"),
+    path('', views.registration, name="registration"),
+    path('contact/add/', views.contact, name="registration_contact_add"),
+    path('contact/bulk_add/', views.contact_bulk_add, name="registration_bulk_add"),
+    path('<int:pk>/edit/', views.contact, name="registration_contact_edit"),
 )

--- a/rapidsms/contrib/registration/views.py
+++ b/rapidsms/contrib/registration/views.py
@@ -3,7 +3,6 @@
 
 import csv
 from io import TextIOWrapper
-import six
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -47,7 +46,7 @@ def contact(request, pk=None):
         data = {}
         for key in request.POST:
             val = request.POST[key]
-            if isinstance(val, six.string_types):
+            if isinstance(val, str):
                 data[key] = val
             else:
                 try:
@@ -85,12 +84,8 @@ def contact_bulk_add(request):
     bulk_form = BulkRegistrationForm(request.POST)
 
     if request.method == "POST" and "bulk" in request.FILES:
-        # Python3's CSV module takes strings while Python2's takes bytes
-        if six.PY3:
-            encoding = request.encoding or settings.DEFAULT_CHARSET
-            f = TextIOWrapper(request.FILES['bulk'].file, encoding=encoding)
-        else:
-            f = request.FILES['bulk']
+        encoding = request.encoding or settings.DEFAULT_CHARSET
+        f = TextIOWrapper(request.FILES['bulk'].file, encoding=encoding)
         reader = csv.reader(
             f,
             quoting=csv.QUOTE_NONE,

--- a/rapidsms/messages/base.py
+++ b/rapidsms/messages/base.py
@@ -5,10 +5,7 @@ import copy
 from uuid import uuid4
 import warnings
 
-from django.utils.encoding import python_2_unicode_compatible
 
-
-@python_2_unicode_compatible
 class MessageBase(object):
     """Basic message representation with text and connection(s)."""
 

--- a/rapidsms/models.py
+++ b/rapidsms/models.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 
 from .utils.modules import try_import, get_classes
 from .conf import settings
@@ -42,7 +41,6 @@ def _find_extensions(app_label, model_name):
     return ext
 
 
-@python_2_unicode_compatible
 class Backend(models.Model):
     """
     This model isn't really a backend. Those are regular Python classes,
@@ -65,7 +63,6 @@ class Backend(models.Model):
             (type(self).__name__, self)
 
 
-@python_2_unicode_compatible
 class App(models.Model):
     """
     This model isn't really a RapidSMS App. Like Backend, it's just a
@@ -95,7 +92,6 @@ class App(models.Model):
             (type(self).__name__, self)
 
 
-@python_2_unicode_compatible
 class ContactBase(models.Model):
     #: The individual's name (optional)
     name = models.CharField(max_length=100, blank=True)
@@ -149,7 +145,6 @@ class Contact(ContactBase):
     __metaclass__ = ExtensibleModelBase
 
 
-@python_2_unicode_compatible
 class ConnectionBase(models.Model):
     #: foreign key to this connection's
     #: :py:class:`~rapidsms.backends.base.BackendBase`

--- a/rapidsms/router/api.py
+++ b/rapidsms/router/api.py
@@ -1,5 +1,4 @@
-import collections
-from six import string_types
+import collections.abc
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -11,7 +10,7 @@ def get_router():
     """Return router defined by RAPIDSMS_ROUTER setting."""
     router = getattr(settings, 'RAPIDSMS_ROUTER',
                      'rapidsms.router.blocking.BlockingRouter')
-    if isinstance(router, string_types):
+    if isinstance(router, str):
         try:
             router = import_class(router)()
         except ImportError as e:
@@ -60,7 +59,7 @@ def send(text, connections, **kwargs):
               in :setting:`RAPIDSMS_ROUTER`.
     :rtype: :py:class:`~rapidsms.messages.outgoing.OutgoingMessage`
     """
-    if not isinstance(connections, collections.Iterable):
+    if not isinstance(connections, collections.abc.Iterable):
         connections = [connections]
     router = get_router()
     message = router.new_outgoing_message(text=text, connections=connections,
@@ -81,7 +80,7 @@ def lookup_connections(backend, identities):
     """
     # imported here so that Models don't get loaded during app config
     from rapidsms.models import Backend
-    if isinstance(backend, string_types):
+    if isinstance(backend, str):
         backend, _ = Backend.objects.get_or_create(name=backend)
     connections = []
     for identity in identities:

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -5,7 +5,6 @@ import logging
 import warnings
 import copy
 from collections import defaultdict
-from six import string_types
 
 from django.db.models.query import QuerySet
 
@@ -53,7 +52,7 @@ class BlockingRouter(object):
         :param module_name: ``AppBase`` object or dotted path to RapidSMS app.
         :returns: ``AppBase`` object if found, otherwise ``None``.
         """
-        if isinstance(module_name, string_types):
+        if isinstance(module_name, str):
             cls = AppBase.find(module_name)
         elif issubclass(module_name, AppBase):
             cls = module_name
@@ -90,7 +89,7 @@ class BlockingRouter(object):
                   object if found, otherwise a ``ValueError`` exception
                   will be raised.
         """
-        if isinstance(module_name, string_types):
+        if isinstance(module_name, str):
             cls = BackendBase.find(module_name)
         elif issubclass(module_name, BackendBase):
             cls = module_name

--- a/rapidsms/router/celery/router.py
+++ b/rapidsms/router/celery/router.py
@@ -26,7 +26,7 @@ class CeleryRouter(BlockingRouter):
 
     def receive_incoming(self, msg):
         """Queue incoming message to be processed in the background."""
-        eager = self.is_eager(msg.connection.backend.name)
+        eager = self.is_eager(msg.connections[0].backend.name)
         if eager:
             logger.debug('Executing in current process')
             receive_async(msg.text, msg.connections[0].pk, msg.id,

--- a/rapidsms/router/celery/tasks.py
+++ b/rapidsms/router/celery/tasks.py
@@ -1,4 +1,4 @@
-import celery
+from celery import shared_task
 from celery.utils.log import get_task_logger
 from rapidsms.errors import MessageSendingError
 
@@ -6,7 +6,7 @@ from rapidsms.errors import MessageSendingError
 logger = get_task_logger(__name__)
 
 
-@celery.task
+@shared_task
 def receive_async(text, connection_id, message_id, fields):
     """Task used to send inbound message through router phases."""
     from rapidsms.models import Connection
@@ -25,7 +25,7 @@ def receive_async(text, connection_id, message_id, fields):
         raise
 
 
-@celery.task
+@shared_task
 def send_async(backend_name, id_, text, identities, context):
     """Task used to send outgoing messages to backends."""
     logger.debug('send_async: %s', text)

--- a/rapidsms/router/db/models.py
+++ b/rapidsms/router/db/models.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
 
 from rapidsms.models import Connection
@@ -22,7 +21,6 @@ STATUS_CHOICES = (
 )
 
 
-@python_2_unicode_compatible
 class Message(models.Model):
     #: Required. See :ref:`message-status-values`.
     status = models.CharField(max_length=1, choices=STATUS_CHOICES,
@@ -76,7 +74,6 @@ class Message(models.Model):
         return self.text[:60]
 
 
-@python_2_unicode_compatible
 class Transmission(models.Model):
     #: Required. Foreign key to associated ``Message``.
     message = models.ForeignKey(Message, related_name='transmissions', on_delete=models.CASCADE)

--- a/rapidsms/router/db/tasks.py
+++ b/rapidsms/router/db/tasks.py
@@ -1,4 +1,4 @@
-import celery
+from celery import shared_task
 from celery.utils.log import get_task_logger
 
 from django.utils.timezone import now
@@ -11,7 +11,7 @@ __all__ = ('receive_async', 'send_transmissions')
 logger = get_task_logger(__name__)
 
 
-@celery.task
+@shared_task
 def receive_async(message_id, fields):
     """Retrieve message from DB and pass to BlockingRouter for processing."""
     from rapidsms.router.db.models import Message
@@ -32,7 +32,7 @@ def receive_async(message_id, fields):
         dbm.set_status()
 
 
-@celery.task
+@shared_task
 def send_transmissions(backend_id, message_id, transmission_ids):
     """Send message to backend with provided transmissions. Retry if failed."""
     from rapidsms.models import Backend

--- a/rapidsms/router/test_api.py
+++ b/rapidsms/router/test_api.py
@@ -33,8 +33,8 @@ class RouterAPITest(harness.RapidTest):
         """Send accepts a single connection."""
         connection = self.create_connection()
         message = send("echo hello", connection)
-        self.assertEqual(message.connection.identity, connection.identity)
-        self.assertEqual(message.connection.backend.name,
+        self.assertEqual(message.connections[0].identity, connection.identity)
+        self.assertEqual(message.connections[0].backend.name,
                          connection.backend.name)
 
     def test_send_with_connections(self):
@@ -42,9 +42,9 @@ class RouterAPITest(harness.RapidTest):
         connections = [self.create_connection(), self.create_connection()]
         message = send("echo hello", connections)
         self.assertEqual(len(message.connections), 2)
-        self.assertEqual(message.connection.identity,
+        self.assertEqual(message.connections[0].identity,
                          connections[0].identity)
-        self.assertEqual(message.connection.backend.name,
+        self.assertEqual(message.connections[0].backend.name,
                          connections[0].backend.name)
 
     def test_saved_message_fields_receive(self):

--- a/rapidsms/tests/harness/base.py
+++ b/rapidsms/tests/harness/base.py
@@ -1,6 +1,4 @@
 from __future__ import unicode_literals
-from six import unichr
-from six.moves import xrange
 import string
 import random
 from django.contrib.auth.models import User
@@ -13,7 +11,7 @@ from rapidsms.messages.incoming import IncomingMessage
 __all__ = ('CreateDataMixin', 'LoginMixin')
 
 
-UNICODE_CHARS = [unichr(x) for x in xrange(1, 0xD7FF)]
+UNICODE_CHARS = [chr(x) for x in range(1, 0xD7FF)]
 
 
 class CreateDataMixin(object):
@@ -38,7 +36,7 @@ class CreateDataMixin(object):
         :param length: Length of generated string.
         """
         output = ''
-        for x in xrange(random.randint(1, max_length / 2)):
+        for x in range(random.randint(1, max_length / 2)):
             c = UNICODE_CHARS[random.randint(0, len(UNICODE_CHARS) - 1)]
             output += c + ' '
         return output

--- a/rapidsms/tests/test_management.py
+++ b/rapidsms/tests/test_management.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from six.moves import StringIO
+from io import StringIO
 
 from django.core.management import call_command
 from django.test import TestCase

--- a/rapidsms/tests/translation/app.py
+++ b/rapidsms/tests/translation/app.py
@@ -5,14 +5,14 @@ from rapidsms.router import send
 from rapidsms.utils import translation as trans_helpers
 
 from django.utils import translation
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 
 class TranslationApp(AppBase):
 
     def handle(self, msg):
         if msg.text == "lang-hello":
-            with translation.override(msg.connection.contact.language):
+            with translation.override(msg.connections[0].contact.language):
                 msg.respond(_('hello'))
             return True
         elif msg.text == 'settings-hello':

--- a/rapidsms/urls/login_logout.py
+++ b/rapidsms/urls/login_logout.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # vim: ai ts=4 sts=4 et sw=4
 
-from django.conf.urls import url
+from django.urls import path
 from .. import views
 
 urlpatterns = (
-    url(r'^login/$', views.RapidSMSLoginView.as_view(), name='rapidsms-login'),
-    url(r'^logout/$', views.RapidSMSLogoutView.as_view(), name='rapidsms-logout'),
+    path('login/', views.RapidSMSLoginView.as_view(), name='rapidsms-login'),
+    path('logout/', views.RapidSMSLogoutView.as_view(), name='rapidsms-logout'),
 )

--- a/rapidsms/utils.py
+++ b/rapidsms/utils.py
@@ -3,7 +3,6 @@
 
 import pytz
 from datetime import datetime
-from six import string_types
 
 
 def empty_str(in_str):
@@ -12,7 +11,7 @@ def empty_str(in_str):
     string reference is None or '' or all whitespace
 
     """
-    if in_str is not None and not isinstance(in_str, string_types):
+    if in_str is not None and not isinstance(in_str, str):
         raise TypeError('Arg must be None or a string type')
 
     return in_str is None or \

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,9 @@ setup(
 
     install_requires=[
         "requests>=1.2.0",
-        "django-tables2==1.21.*",
+        "django-tables2>=2.1.1",
         "djappsettings>=0.4.0",
         "django-selectable>=0.7.0",
-        "six",
     ],
 
     packages=find_packages(),
@@ -44,14 +43,12 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Framework :: Django',
-        'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.2',
         'Development Status :: 5 - Production/Stable',
         'Operating System :: OS Independent',
     ],

--- a/tests/default.py
+++ b/tests/default.py
@@ -118,3 +118,5 @@ app.config_from_object('django.conf:settings')
 
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tests/requirements/dev.txt
+++ b/tests/requirements/dev.txt
@@ -1,2 +1,2 @@
-celery>=3.1
+celery>=5.2.1
 mock==1.0.1

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 from rapidsms import views as rapidsms_views
@@ -6,18 +6,18 @@ from rapidsms import views as rapidsms_views
 admin.autodiscover()
 
 urlpatterns = (
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 
     # RapidSMS core URLs
-    url(r'^account/', include('rapidsms.urls.login_logout')),
-    url(r'^$', rapidsms_views.dashboard, name='rapidsms-dashboard'),
+    path('account/', include('rapidsms.urls.login_logout')),
+    path('', rapidsms_views.dashboard, name='rapidsms-dashboard'),
 
     # RapidSMS contrib app URLs
-    url(r'^httptester/', include('rapidsms.contrib.httptester.urls')),
-    url(r'^messagelog/', include('rapidsms.contrib.messagelog.urls')),
-    url(r'^messaging/', include('rapidsms.contrib.messaging.urls')),
-    url(r'^registration/', include('rapidsms.contrib.registration.urls')),
+    path('httptester/', include('rapidsms.contrib.httptester.urls')),
+    path('messagelog/', include('rapidsms.contrib.messagelog.urls')),
+    path('messaging/', include('rapidsms.contrib.messaging.urls')),
+    path('registration/', include('rapidsms.contrib.registration.urls')),
 
     # Third party URLs
-    url(r'^selectable/', include('selectable.urls')),
+    path('selectable/', include('selectable.urls')),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = {py37,py38}-{dj22,dj32}
-          py38-migrations,
-          py38-docs,
-          py38-flake8,
-          py38-coverage
+envlist = {py37,py38,py39}-{dj22,dj32}
+          py39-migrations,
+          py39-docs,
+          py39-flake8,
+          py39-coverage
 
 [default]
 deps = pip>9
@@ -13,6 +13,7 @@ deps = pip>9
 basepython =
      py37: python3.7
      py38: python3.8
+     py39: python3.9
 deps =
     dj22: Django>=2.2,<3.0
     dj32: Django>=3.2,<4.0
@@ -21,28 +22,28 @@ setenv = PYTHON_PATH = {toxinidir}
          DJANGO_SETTINGS_MODULE = tests.default
 commands = {envpython} -Wd run_tests.py {posargs}
 
-[testenv:py38-migrations]
-basepython = python3.8
+[testenv:py39-migrations]
+basepython = python3.9
 deps = Django>=3.2,<4.0
        {[default]deps}
 setenv = {[testenv]setenv}
 commands = django-admin makemigrations --dry-run --check
 
-[testenv:py38-docs]
-basepython = python3.8
+[testenv:py39-docs]
+basepython = python3.9
 deps = Sphinx>=1.7,<1.8
        Django>=3.2,<4.0
        {[default]deps}
 commands =
     {envbindir}/sphinx-build -a -n -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py38-flake8]
-basepython = python3.8
+[testenv:py39-flake8]
+basepython = python3.9
 deps = flake8
 commands = flake8 rapidsms
 
-[testenv:py38-coverage]
-basepython = python3.8
+[testenv:py39-coverage]
+basepython = python3.9
 commands = coverage run run_tests.py
            coverage report -m --fail-under=85
 deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = {py27,py36,py37}-dj111,
-          {py36,py37}-{dj20,dj21,dj22}
-          {py27,py37}-migrations,
-          py37-docs,
-          py37-flake8,
-          py37-coverage
+envlist = {py37,py38}-{dj22,dj32}
+          py38-migrations,
+          py38-docs,
+          py38-flake8,
+          py38-coverage
 
 [default]
 deps = pip>9
@@ -12,50 +11,40 @@ deps = pip>9
 
 [testenv]
 basepython =
-     py27: python2.7
-     py36: python3.6
      py37: python3.7
+     py38: python3.8
 deps =
-    dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
+    dj32: Django>=3.2,<4.0
     {[default]deps}
 setenv = PYTHON_PATH = {toxinidir}
          DJANGO_SETTINGS_MODULE = tests.default
 commands = {envpython} -Wd run_tests.py {posargs}
 
-[testenv:py27-migrations]
-basepython = python2.7
-deps = Django>=1.11,<2.0
+[testenv:py38-migrations]
+basepython = python3.8
+deps = Django>=3.2,<4.0
        {[default]deps}
 setenv = {[testenv]setenv}
-commands = django-admin.py makemigrations --dry-run --check
+commands = django-admin makemigrations --dry-run --check
 
-[testenv:py37-migrations]
-basepython = python3.7
-deps = Django>=2.2,<3.0
-       {[default]deps}
-setenv = {[testenv]setenv}
-commands = django-admin.py makemigrations --dry-run --check
-
-[testenv:py37-docs]
-basepython = python3.7
+[testenv:py38-docs]
+basepython = python3.8
 deps = Sphinx>=1.7,<1.8
-       Django>=2.2,<3.0
+       Django>=3.2,<4.0
        {[default]deps}
 commands =
     {envbindir}/sphinx-build -a -n -W -b html -d docs/_build/doctrees docs docs/_build/html
 
-[testenv:py37-flake8]
-basepython = python3.7
+[testenv:py38-flake8]
+basepython = python3.8
 deps = flake8
 commands = flake8 rapidsms
 
-[testenv:py37-coverage]
-basepython = python3.7
+[testenv:py38-coverage]
+basepython = python3.8
 commands = coverage run run_tests.py
            coverage report -m --fail-under=85
 deps = coverage
-       Django>=2.2,<3.0
+       Django>=3.2,<4.0
        {[default]deps}


### PR DESCRIPTION
- Stop use of deprecated BaseMessage.connection
- celery.task has been removed, use shared_task
- Remove references to Python 2 compatibility utils
- Update django-tables2 to a post-Python-2 version
- Remove usages of deprecated Django features
- Specify default_auto_field to avoid unintended migrations
- Use celery>=5.2.1 in tests to avoid deprecation warnings
- Drop support for EOL Python 3.6
- [x] `tox` passes all checks