### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/docs/releases/0.13.0.rst
+++ b/docs/releases/0.13.0.rst
@@ -130,7 +130,7 @@ architecture.
 Changed ``Backend.send`` signature
 ----------------------------------
 
-All exisitng backends must be updated to use the new signature. The router used
+All existing backends must be updated to use the new signature. The router used
 to pass just a message object to :meth:`BackendBase.send
 <rapidsms.backends.base.BackendBase.send>`. The signature has been updated to
 accept an ``id_``, ``text``, list of ``identities``, and a ``context``

--- a/docs/topics/deployment/paas.rst
+++ b/docs/topics/deployment/paas.rst
@@ -4,7 +4,7 @@
 Running on a PaaS Provider
 ==========================
 
-In choosing to run a project on a PaaS provider, you are choosing simplicitiy over
+In choosing to run a project on a PaaS provider, you are choosing simplicity over
 ability to easily customize and transfer your installation. Each of these
 companies provide a custom command line tool for automatically configuring and
 deploying an application.

--- a/docs/topics/deployment/telecom.rst
+++ b/docs/topics/deployment/telecom.rst
@@ -42,7 +42,7 @@ There are many reputable international SMS gateways, although their service and 
 
 **Pros:**
 
-* Can provide strong technical infrastructre and volume discounts
+* Can provide strong technical infrastructure and volume discounts
 
 **Cons:**
 
@@ -58,7 +58,7 @@ One common solution we use is to take a local SIM card from a given country, ena
 **Pros:**
 
 * Users can text a local number cheaply
-* Can provide strong technical infrastructre and volume discounts
+* Can provide strong technical infrastructure and volume discounts
 
 **Cons:**
 
@@ -84,4 +84,4 @@ Most SMS services are offered through third-party SMS gateways, whose business i
 Terminology
 ===============
 
-**Gateway:** A gateway is a web service which provides access to particular services. A website can interface with an SMS gateway over the internet in order to send and recieve SMS.
+**Gateway:** A gateway is a web service which provides access to particular services. A website can interface with an SMS gateway over the internet in order to send and receive SMS.

--- a/docs/topics/extensible-models.rst
+++ b/docs/topics/extensible-models.rst
@@ -39,7 +39,7 @@ These are all fairly dumb apps for the sake of this example, so only contact.py 
             abstract = True
 
 
-The folder structure here is very important: we're extending the Contact model, within the rapidsms app. So the modeule where our extension class exists "must" be myapp/extensions/rapidsms/contact.py. The name of the class itself, TestContact, is unimportant, however it "must" be abstract. Any abstract models within this module will have their attributes added to the base Contact class.
+The folder structure here is very important: we're extending the Contact model, within the rapidsms app. So the module where our extension class exists "must" be myapp/extensions/rapidsms/contact.py. The name of the class itself, TestContact, is unimportant, however it "must" be abstract. Any abstract models within this module will have their attributes added to the base Contact class.
 
 In testextensions_clash, I used the same exact TestContact model (it also has a boolean is_used attribute).
 
@@ -157,6 +157,6 @@ In this case the clash is identified and in fact impossible to create.
 Conclusions
 --------------
     
-South provides an easy way to add new attributes to ExtensibleModels, within an already-deploayed instance of RapidSMS.
+South provides an easy way to add new attributes to ExtensibleModels, within an already-deployed instance of RapidSMS.
 
 Depending on your needs, south-managed migrations and regular syncdb offer different behaviors for attribute clashes with extensible models used by two separate apps. In either case, if two groups within the community are working on apps that extend the same model (and that both use one another's apps), they should probably be coordinating regularly when adding attributes, to be sure there are no clashes, and to determine which attributes should be brought into the base class.

--- a/docs/topics/i18n.rst
+++ b/docs/topics/i18n.rst
@@ -34,7 +34,7 @@ LANGUAGE_CODE>`_.
 
 RapidSMS will not automatically attempt to translate routed
 messages. This is an intential decision to require application developers to
-explicity initiate the message translation process. You can use the methods
+explicitly initiate the message translation process. You can use the methods
 below to translate messages.
 
 

--- a/docs/topics/testing.rst
+++ b/docs/topics/testing.rst
@@ -214,7 +214,7 @@ The script is interpreted like so:
 * **number > message-text**
     * Represents an incoming message from **number** whose contents is **message-text**
 * **number < message-text**
-    * Represents an outoing message sent to **number** whose contents is **message-text**
+    * Represents an outgoing message sent to **number** whose contents is **message-text**
 
 The entire script is parsed and executed against the RapidSMS router.
 

--- a/rapidsms/contrib/httptester/views.py
+++ b/rapidsms/contrib/httptester/views.py
@@ -64,7 +64,7 @@ def message_tester(request, identity):
                         storage.store_and_queue(identity, line)
                     messages.add_message(request, messages.INFO, "Sent bulk messages")
                 # no bulk file was submitted, so use the "single message"
-                # field. this may be empty, which is fine, since contactcs
+                # field. this may be empty, which is fine, since contacts
                 # can (and will) submit empty sms, too.
                 else:
                     storage.store_and_queue(identity, cd["text"])

--- a/rapidsms/contrib/messaging/static/messaging/javascripts/jquery.simplyCountable.js
+++ b/rapidsms/contrib/messaging/static/messaging/javascripts/jquery.simplyCountable.js
@@ -106,7 +106,7 @@
     countCheck();
     countable.keyup(countCheck);
     countable.bind('paste', function(){
-      // Wait a few miliseconds for the pasting
+      // Wait a few milliseconds for the pasting
       setTimeout(countCheck, 5);
     });
     

--- a/rapidsms/router/blocking/router.py
+++ b/rapidsms/router/blocking/router.py
@@ -297,7 +297,7 @@ class BlockingRouter(object):
 
         :param text: Message text
         :param connections: List or QuerySet of ``Connection`` objects
-        :param class_: Message class to instaniate
+        :param class_: Message class to instantiate
         :returns: :class:`IncomingMessage <rapidsms.messages.incoming.IncomingMessage>` object.
         """
         return class_(text=text, connections=connections,
@@ -311,7 +311,7 @@ class BlockingRouter(object):
 
         :param text: Message text
         :param connections: List or QuerySet of ``Connection`` objects
-        :param class_: Message class to instaniate
+        :param class_: Message class to instantiate
         :returns: :class:`OutgoingMessage <rapidsms.messages.outgoing.OutgoingMessage>` object.
         """
         return class_(text=text, connections=connections, **kwargs)

--- a/rapidsms/router/db/router.py
+++ b/rapidsms/router/db/router.py
@@ -36,7 +36,7 @@ class DatabaseRouter(BlockingRouter):
         msg = super(DatabaseRouter, self).new_incoming_message(connections,
                                                                text,
                                                                **kwargs)
-        # save and attach database meessage to message object
+        # save and attach database message to message object
         msg.dbm = self.queue_message("I", connections, text, **kwargs)
         # set id of message to the database message primary key
         msg.id = msg.dbm.pk

--- a/rapidsms/router/db/tasks.py
+++ b/rapidsms/router/db/tasks.py
@@ -68,7 +68,7 @@ def send_transmissions(backend_id, message_id, transmission_ids):
         transmissions.update(status='E', updated=now())
         # Retry the task
         raise send_transmissions.retry(exc=exc)
-    # no error occured, so mark these transmissions as sent
+    # no error occurred, so mark these transmissions as sent
     transmissions.update(status='S', sent=now())
     # we don't know if there are more transmissions pending, so
     # we always set the status at the end of each batch

--- a/rapidsms/router/db/tests.py
+++ b/rapidsms/router/db/tests.py
@@ -123,7 +123,7 @@ class DatabaseRouterReceiveTest(harness.DatabaseBackendMixin, TestCase):
         self.assertEqual(1, dbm.transmissions.count())
 
     def test_receive_status(self):
-        """Inbound messages should be marked with R if no errors occured."""
+        """Inbound messages should be marked with R if no errors occurred."""
         self.receive(text="foo", connection=self.conn1)
         dbm = Message.objects.all()[0]
         self.assertEqual("R", dbm.status)
@@ -132,7 +132,7 @@ class DatabaseRouterReceiveTest(harness.DatabaseBackendMixin, TestCase):
 
     @patch.object(EchoHandler, 'handle')
     def test_receive_status_with_error(self, mock_handle):
-        """Inbound messages should be marked with E if an error occured."""
+        """Inbound messages should be marked with E if an error occurred."""
         mock_handle.side_effect = Exception
         self.receive(text="echo foo", connection=self.conn1)
         dbm = Message.objects.all()[0]
@@ -220,7 +220,7 @@ class DatabaseRouterSendTest(harness.DatabaseBackendMixin, TestCase):
             message.transmissions.create(connection=connection, status="Q")
 
     def test_send_successful_status(self):
-        """Transmissions should be marked with S if no errors occured."""
+        """Transmissions should be marked with S if no errors occurred."""
         # create 2 batches (queued, queued)
         dbm, t1, t2 = self.create_trans(s1='Q', s2='Q')
         send_transmissions(self.backend.pk, dbm.pk, t1.values_list('id', flat=True))

--- a/rapidsms/tests/test_management.py
+++ b/rapidsms/tests/test_management.py
@@ -9,7 +9,7 @@ class UpdateAppsAndBackendsTest(TestCase):
 
     def setUp(self):
         self.output = StringIO()
-        # BASE_APPS are needed for the managment commands to load successfully
+        # BASE_APPS are needed for the management commands to load successfully
         self.BASE_APPS = [
             'rapidsms',
             'django.contrib.auth',


### PR DESCRIPTION
There are small typos in:
- docs/releases/0.13.0.rst
- docs/topics/deployment/paas.rst
- docs/topics/deployment/telecom.rst
- docs/topics/extensible-models.rst
- docs/topics/i18n.rst
- docs/topics/testing.rst
- rapidsms/contrib/httptester/views.py
- rapidsms/contrib/messaging/static/messaging/javascripts/jquery.simplyCountable.js
- rapidsms/router/blocking/router.py
- rapidsms/router/db/router.py
- rapidsms/router/db/tasks.py
- rapidsms/router/db/tests.py
- rapidsms/tests/test_management.py

Fixes:
- Should read `occurred` rather than `occured`.
- Should read `instantiate` rather than `instaniate`.
- Should read `simplicity` rather than `simplicitiy`.
- Should read `receive` rather than `recieve`.
- Should read `outgoing` rather than `outoing`.
- Should read `module` rather than `modeule`.
- Should read `milliseconds` rather than `miliseconds`.
- Should read `message` rather than `meessage`.
- Should read `management` rather than `managment`.
- Should read `infrastructure` rather than `infrastructre`.
- Should read `explicitly` rather than `explicity`.
- Should read `existing` rather than `exisitng`.
- Should read `deployed` rather than `deploayed`.
- Should read `contacts` rather than `contactcs`.

Closes #494